### PR TITLE
feat: Implement warehouse_iot session

### DIFF
--- a/Routes/by_FindWH.js
+++ b/Routes/by_FindWH.js
@@ -17,7 +17,9 @@ exports.findWH = function (req, res,app,db) {
                 "\"useableArea\" :"+ results[step].useableArea +","+
                 "\"price\" :"+ results[step].price +","+
                 "\"infoComment\" :\""+ results[step].infoComment+"\","+
-               "\"etcComment\" :\""+ results[step].etcComment+"\""+
+               "\"etcComment\" :\""+ results[step].etcComment+"\","+
+                "\"zipcode\" :\""+ results[step].zipcode+"\","+
+                "\"useIot\" :"+ results[step].useIot+
             "}";
             items+=obj;
             if(step+1!=results.length)items+=","

--- a/Routes/by_MyWH.js
+++ b/Routes/by_MyWH.js
@@ -52,7 +52,9 @@ exports.Mywarehouse = function(req,res,app,db){
               "\"price\" :"+ results[step].price +","+
               "\"area\":" +results[step].area+","+
               "\"infoComment\" :\""+ results[step].infoComment+"\","+
-              "\"etcComment\" :\""+ results[step].etcComment+"\""+
+              "\"etcComment\" :\""+ results[step].etcComment+"\","+
+              "\"zipcode\" :\""+ results[step].zipcode+"\","+
+              "\"useIot\" :"+ results[step].useIot+
           "}";
           items+=obj;
 
@@ -171,5 +173,5 @@ exports.ReqBuyWithAnswer = function(req,res,app,db){
 }
 
 exports.GetAmountsForItems = function(req,res,app,db){
-  
+
 }

--- a/Routes/iot.js
+++ b/Routes/iot.js
@@ -4,7 +4,6 @@ module.exports = function(app,db){
 	const router = express.Router();
 
 	const iot_mypage = require('./iot_mypage');
-	const iot_monitoring = require('./iot_monitoring');
 	const iot_warehousing = require('./iot_warehousing');
 
 	var check = (req, res, next) => {
@@ -25,7 +24,7 @@ module.exports = function(app,db){
 	router.get('/', (req, res, next) => { iot_mypage.init(req, res, db) });
 	router.post('/', (req, res, next) => { iot_mypage.sessionCheck(req, res, db) });
 
-	router.get('/monitoring', (req, res, next) => { iot_monitoring.init(req, res, db) });
+	router.get('/monitoring', (req, res, next) => { res.render('Iot/monitoring') });
 
 	router.get('/warehousing', (req, res, next) => { iot_warehousing.init(req, res, db) });
 

--- a/Routes/iot.js
+++ b/Routes/iot.js
@@ -7,6 +7,21 @@ module.exports = function(app,db){
 	const iot_monitoring = require('./iot_monitoring');
 	const iot_warehousing = require('./iot_warehousing');
 
+	var check = (req, res, next) => {
+		var id = req.session['memberID'];
+		var wid = req.session['warehouseID'];
+		var ref = req.headers.referer ? req.headers.referer.toLowerCase() : '';
+		const refererPaths = ['/provider/mywarehouse', '/buyer/mywarehouse', '/iot', '/iot/monitoring', '/iot/warehousing', '/iot/help'];
+
+		// /iot 하위 모든 경로에 대해 검사
+		if (!id) res.redirect('/User/Login');  // 로그인 안한 상태: out
+		else if (req.path === '/' && req.method === 'POST') return next();  // 세션에 wid 등록하는 요청은 pass
+		else if (!wid) res.send('잘못된 접근입니다.');  // 세션에 wid 없음: out
+		else if (refererPaths.every((e) => !ref.includes(e))) res.send('잘못된 접근입니다.');  // referer가 refererPaths에 포함되지 않음: out
+		else next();  // 모두 통과: ok
+	};
+	router.use(check);
+
 	router.get('/', (req, res, next) => { iot_mypage.init(req, res, db) });
 	router.post('/', (req, res, next) => { iot_mypage.sessionCheck(req, res, db) });
 

--- a/Routes/iot.js
+++ b/Routes/iot.js
@@ -3,11 +3,12 @@ module.exports = function(app,db){
 	const express = require('express');
 	const router = express.Router();
 
-	var iot_mypage = require('./iot_mypage');
+	const iot_mypage = require('./iot_mypage');
 	const iot_monitoring = require('./iot_monitoring');
 	const iot_warehousing = require('./iot_warehousing');
 
 	router.get('/', (req, res, next) => { iot_mypage.init(req, res, db) });
+	router.post('/', (req, res, next) => { iot_mypage.sessionCheck(req, res, db) });
 
 	router.get('/monitoring', (req, res, next) => { iot_monitoring.init(req, res, db) });
 

--- a/Routes/iot_monitoring.js
+++ b/Routes/iot_monitoring.js
@@ -1,4 +1,0 @@
-exports.init = function(req, res, db) {
-	if(!req.session['memberID']) res.status(401).render('unauthorized');
-	else res.render('Iot/monitoring');
-}

--- a/Routes/iot_mypage.js
+++ b/Routes/iot_mypage.js
@@ -1,9 +1,27 @@
 exports.init = function(req, res, db) {
     var id = req.session['memberID'];
-	if(!id) res.status(401).render('unauthorized');
+    var wid = req.session['warehouseID'];
+	if(!id) res.redirect('/User/Login');
+	else if (!wid) res.status(401).send('잘못된 접근입니다.');
 	else {
-		var row = db.query("SELECT * FROM Member WHERE memberID = ?;", [id]);
+		var row = db.query("SELECT * FROM Member WHERE memberID=?;", [id]);
 		if (!row) console.log('err: mypage');
 		else res.render('Iot/mypage', {uname: row[0].name});
     }
+}
+
+
+exports.sessionCheck = function (req, res, db) {
+	var id = req.session['memberID'];
+	var wid = req.body.wid;
+	if(!id) res.redirect('/User/Login');
+	else {
+		var row = db.query(`select count(*) as num from (select memberID, warehouseID from Provider union select memberID, warehouseID from Buyer) as pb where memberID=? and warehouseID=?;`, [id, wid]);
+		if (!row) console.log('err: iot.sessionCheck');
+		else if (!row[0].num) res.status(401).send('잘못된 접근입니다.');
+		else {
+			req.session['warehouseID'] = wid;
+			res.redirect('/iot');
+		}
+	}
 }

--- a/Routes/iot_mypage.js
+++ b/Routes/iot_mypage.js
@@ -9,14 +9,11 @@ exports.init = function(req, res, db) {
 exports.sessionCheck = function (req, res, db) {
 	var id = req.session['memberID'];
 	var wid = req.body.wid;
-	if(!id) res.redirect('/User/Login');
+	var row = db.query(`select count(*) as num from (select memberID, warehouseID from Provider union select memberID, warehouseID from Buyer) as pb where memberID=? and warehouseID=?;`, [id, wid]);
+	if (!row) console.log('err: iot.sessionCheck');
+	else if (!row[0].num) res.status(401).send('잘못된 접근입니다.');  // 창고 provider/buyer가 아님
 	else {
-		var row = db.query(`select count(*) as num from (select memberID, warehouseID from Provider union select memberID, warehouseID from Buyer) as pb where memberID=? and warehouseID=?;`, [id, wid]);
-		if (!row) console.log('err: iot.sessionCheck');
-		else if (!row[0].num) res.status(401).send('잘못된 접근입니다.');
-		else {
-			req.session['warehouseID'] = wid;
-			res.redirect('/iot');
-		}
+		req.session['warehouseID'] = wid;
+		res.redirect('/iot');
 	}
 }

--- a/Routes/iot_mypage.js
+++ b/Routes/iot_mypage.js
@@ -1,15 +1,8 @@
 exports.init = function(req, res, db) {
     var id = req.session['memberID'];
-    var wid = req.session['warehouseID'];
-    var ref = req.headers.referer ? req.headers.referer.slice(-21) : '';
-	if(!id) res.redirect('/User/Login');
-	else if (!wid) res.status(401).send('잘못된 접근입니다.');
-	else if (ref !== '/Provider/MyWarehouse' && ref !== '/Buyer/MyWarehouse') res.status(401).send('잘못된 접근입니다.');
-	else {
-		var row = db.query("SELECT * FROM Member WHERE memberID=?;", [id]);
-		if (!row) console.log('err: mypage');
-		else res.render('Iot/mypage', {uname: row[0].name});
-    }
+	var row = db.query("SELECT * FROM Member WHERE memberID=?;", [id]);
+	if (!row) console.log('err: mypage');
+	else res.render('Iot/mypage', {uname: row[0].name});
 }
 
 

--- a/Routes/iot_mypage.js
+++ b/Routes/iot_mypage.js
@@ -1,8 +1,10 @@
 exports.init = function(req, res, db) {
     var id = req.session['memberID'];
     var wid = req.session['warehouseID'];
+    var ref = req.headers.referer ? req.headers.referer.slice(-21) : '';
 	if(!id) res.redirect('/User/Login');
 	else if (!wid) res.status(401).send('잘못된 접근입니다.');
+	else if (ref !== '/Provider/MyWarehouse' && ref !== '/Buyer/MyWarehouse') res.status(401).send('잘못된 접근입니다.');
 	else {
 		var row = db.query("SELECT * FROM Member WHERE memberID=?;", [id]);
 		if (!row) console.log('err: mypage');

--- a/Routes/iot_warehousing.js
+++ b/Routes/iot_warehousing.js
@@ -1,24 +1,22 @@
 exports.init = function(req, res, db) {
-	if(!req.session['memberID']) res.status(401).render('unauthorized');
+	var id = req.session['memberID'];
+	var row = db.query("SELECT * FROM iot WHERE id=?;", [id]);
+	if (!row) console.log('err: warehousing init');
 	else {
-		var row = db.query("SELECT * FROM iot WHERE id=?;", [req.session['memberID']]);
-			if (!row) console.log('err: warehousing init');
-			else {
-				var items = '';
-				for (var i = 0; i < row.length; i++) {
-					row[i].received = row[i].received ? '입고완료' : '미입고';
-					items += `
-					<tr>
-						<td>${row[i].rfid}</td>
-						<td>${row[i].name}</td>
-						<td>${row[i].num}</td>
-						<td>${row[i].received}</td>
-						<td><button class="checkBtn" onclick="location.href='${row[i].picture}'">확인</button></td>
-					</tr>
-				  `;
-				}
-				res.render('Iot/warehousing', {table_data: items});
-			}
+		var items = '';
+		for (var i = 0; i < row.length; i++) {
+			row[i].received = row[i].received ? '입고완료' : '미입고';
+			items += `
+			<tr>
+				<td>${row[i].rfid}</td>
+				<td>${row[i].name}</td>
+				<td>${row[i].num}</td>
+				<td>${row[i].received}</td>
+				<td><button class="checkBtn" onclick="location.href='${row[i].picture}'">확인</button></td>
+			</tr>
+		  `;
+		}
+		res.render('Iot/warehousing', {table_data: items});
 	}
 }
 
@@ -31,12 +29,9 @@ exports.registerItem = function(req, res, db) {
 	var picture = `./${rfid}.jpg`;
 	var id = req.session['memberID'];
 
-	if(!id) res.status(401).render('unauthorized');
-	else {
-		var row = db.query(`INSERT INTO iot VALUES('${rfid}', '${id}', '${name}', ${num}, ${received}, '${picture}');`);
-		if (!row) console.log('err: registerItem');
-		else res.redirect('warehousing');
-	}
+	var row = db.query(`INSERT INTO iot VALUES('${rfid}', '${id}', '${name}', ${num}, ${received}, '${picture}');`);
+	if (!row) console.log('err: registerItem');
+	else res.redirect('warehousing');
 }
 
 
@@ -49,10 +44,7 @@ exports.randomTest = function(req, res, db) {
 	var picture = `./${rfid}.jpg`;
 	var id = req.session['memberID'];
 
-	if(!id) res.status(401).render('unauthorized');
-	else {
-		var row = db.query(`INSERT INTO iot VALUES('${rfid}', '${id}', '${name}', ${num}, ${received}, '${picture}');`);
-			if (!row) console.log('err: randomTest');
-			else res.redirect('warehousing');
-	}
+	var row = db.query(`INSERT INTO iot VALUES('${rfid}', '${id}', '${name}', ${num}, ${received}, '${picture}');`);
+		if (!row) console.log('err: randomTest');
+		else res.redirect('warehousing');
 }

--- a/Routes/pv_EnrollWH.js
+++ b/Routes/pv_EnrollWH.js
@@ -22,7 +22,8 @@ exports.EnrollWH = function(req,res,app,db,fileName){
     "useableArea":  req.body.floorArea,
     "price": req.body.price,
     "infoComment": req.body.infoComment,
-    "etcComment" :req.body.etcComment
+    "etcComment" :req.body.etcComment,
+    "useIot" :0
   };
 
   //예외처리를 위한 정규식
@@ -60,7 +61,8 @@ exports.EnrollWH = function(req,res,app,db,fileName){
             "useableArea":  req.body.floorArea,
             "price": req.body.price,
             "infoComment": req.body.infoComment,
-            "etcComment" :req.body.etcComment
+            "etcComment" :req.body.etcComment,
+            "useIot" :0
         }
         let reqResult = db.query('SELECT * from RequestForEnroll ORDER BY reqID DESC');
         //let logResult = db.query('SELECT * from Log ORDER BY logID DESC');

--- a/Routes/pv_MyWH.js
+++ b/Routes/pv_MyWH.js
@@ -83,7 +83,9 @@ exports.Mywarehouse = function(req,res,app,db){
               "\"useableArea\" :"+ results[step].useableArea +","+
               "\"infoComment\" :\""+ results[step].infoComment+"\","+
               "\"etcComment\" :\""+ results[step].etcComment+"\","+
-              "\"memberList\": ["; 
+              "\"zipcode\" :\""+ results[step].zipcode+"\","+
+              "\"useIot\" :"+ results[step].useIot+","+
+              "\"memberList\": [";
               for(i =0;i<idList.length;i++){
                obj+="\""+idList[i].memberID+"\"";
                 if(i+1<idList.length)obj+=",";
@@ -116,7 +118,7 @@ exports.ReqEnrollAns = function(req,res,app,db){
         res.send(true);
         connection.end();
       }
-    });    
+    });
   }
     else if(answer="Cancel"){
       connection.query(`DELETE FROM RequestForEnroll WHERE reqID =${reqID}`,function (error, results, fields) {

--- a/Views/User/Provider/pv_MyWH.ejs
+++ b/Views/User/Provider/pv_MyWH.ejs
@@ -28,6 +28,14 @@
                   </a>
                 </div>
                 <div id="collapse<%=i%>" class="collapse" data-parent="#accordion">
+                  <% if (wList['item' + i].useIot) { %>
+                    <div style="text-align: right; padding-right: 5%;">
+                      <form action="/iot" method="POST">
+                        <input type="hidden" id="wid" name="wid" value="<%= wList['item' + i].warehouseID %>">
+                        <button class="btn btn-primary">IoT</button>
+                      </form>
+                    </div>
+                  <% } %>
                   <div class="card-body">
                     <table class="board-table table ">
                       <a style = "font-size:24px">창고 정보</a>
@@ -53,7 +61,7 @@
                       <table class="table table-striped ">
                         <a style = "font-size:24px">거래 내역</a>
                         <thead class="thead-dark">
-                          <tr class="d-flex">  
+                          <tr class="d-flex">
                             <th class="col-2">창고번호</th>
                             <th class="col-1">거래금액($)</th>
                             <th class="col-3">대여기간</th>
@@ -62,13 +70,14 @@
                             <th class="col-2">email</th>
                             <th class="col-1">국적</th>
                             <th class="col-1">회사 이름</th>
+                            <th class="col-1">우편번호</th>
                             <th class="col-3">회사 주소</th>
                             <th></th>
                           </tr>
                         </thead>
                         <tbody>
                           <tbody>
-                            <% for(var j=0; j < Object.keys(requestItems).length; j++) { %>     
+                            <% for(var j=0; j < Object.keys(requestItems).length; j++) { %>
                               <%if(requestItems['item'+j].reqType == 'ReqPayAcpt' && wList['item'+i].warehouseID == requestItems['item'+j].warehouseID) { %>
                                 <tr class="d-flex">
                                   <td class="col-2"><%= requestItems['item'+j].warehouseID %></td>
@@ -79,6 +88,7 @@
                                   <td class="col-2"><%= requestItems['item'+j].email%></td>
                                   <td class="col-1"><%= requestItems['item'+j].national%></td>
                                   <td class="col-1"><%= requestItems['item'+j].CN%></td>
+                                  <td class="col-1"><%= requestItems['item'+j].CZ%></td>
                                   <td class="col-3"><%= requestItems['item'+j].CA%></td>
                                   <td></td>
                                 </tr>
@@ -87,7 +97,7 @@
                            </tbody>
                          </tbody>
                       </table>
-                    </div>                        
+                    </div>
                   </div>      <!-- card body-->
                </div>         <!-- collapse-->
              </div>           <!-- class card-->
@@ -135,7 +145,7 @@
             </tbody>
           </table>
         </div>
-        
+
         <div class="container mb-4">
           <h2 class="mb-3">Buy Request lists</h2>
           <% for(var i=0; i < Object.keys(requestItems).length; i++) { %>


### PR DESCRIPTION
## 개요
User-Warehouse 접근 제어 구현

## 작업사항
- Provider/MyWarehouse 페이지에 창고별 IoT 버튼 추가 (iot 페이지로 이동)
- IoT 버튼을 누르면 세션에 wid를 등록, 이를 이용해 창고 식별
- 세션의 wid를 이용해 비정상적인 접근 통제
- Referer를 이용해 비정상적인 접근 통제
- iot 및 하위 페이지 로그인 체크 기능 리팩토링

### 변경전
- 창고 ID를 모르는 상황에서 iot 페이지로 접근이 가능
- 창고가 없는 유저도 접근이 가능

### 변경후
- 상기 내용을 해결

## 사용방법
- 별도 db 수정
- Provider로 로그인 &rarr; My Warehouse 페이지 &rarr; db에서 iot 사용 등록 된 창고는 IoT 버튼이 생김.

## 기타
- /iot/*, /Provider/MyWarehouse, /Buyer/MyWarehouse 를 제외한 기타 페이지에서 iot 페이지로 접근할 경우 비정상적인 접근으로 간주됨.
- 추후 구글맵 API 토큰을 발급 받으면 Buyer/MyWarehouse 부분 수정 예정
