### PR TITLE
feat: Show alert inaccessible page

### DIFF
--- a/Routes/ad.js
+++ b/Routes/ad.js
@@ -6,6 +6,14 @@ module.exports = function(app,db){
     const ad_ReqBuy = require('./ad_RequestBuy');
     const ad_ContractInfo = require('./ad_ContractInfo');
 
+    var check = (req, res, next) => {
+        var type = req.session['type'];
+        if (!type) res.render('Alert/needLogin');
+        else if (type === 'admin') next();
+        else res.render('Alert/cannotAccess');
+    };
+    router.use(check);
+
     router.get('/RequestEnroll',function(req,res,next){
         var items = ad_ReqEnroll.RequestForEnroll(req,res,app,db);
         console.log(items);

--- a/Routes/by.js
+++ b/Routes/by.js
@@ -4,6 +4,14 @@ module.exports = function(app,db){
     var findWH = require('./by_FindWH');
     var MyWH = require('./by_MyWH');
 
+    var check = (req, res, next) => {
+        var type = req.session['type'];
+        if (!type) res.render('Alert/needLogin');
+        else if (type === 'buyer') next();
+        else res.render('Alert/cannotAccess');
+    };
+    router.use(check);
+
     router.get('/',function(req,res,next){
         res.render('User/Buyer/by_FindWH',{'app':app,'session':req.session,'db':db});
     });

--- a/Routes/iot.js
+++ b/Routes/iot.js
@@ -9,15 +9,15 @@ module.exports = function(app,db){
 	var check = (req, res, next) => {
 		var id = req.session['memberID'];
 		var wid = req.session['warehouseID'];
-		var ref = req.headers.referer ? req.headers.referer.toLowerCase() : '';
+		var hostIndex = (req.protocol + '://' + req.get('host')).length;
+		var ref = req.headers.referer ? req.headers.referer.toLowerCase().substring(hostIndex) : '';
 		const refererPaths = ['/provider/mywarehouse', '/buyer/mywarehouse', '/iot', '/iot/monitoring', '/iot/warehousing', '/iot/help'];
 
-		// /iot 하위 모든 경로에 대해 검사
-		if (!id) res.redirect('/User/Login');  // 로그인 안한 상태: out
-		else if (req.path === '/' && req.method === 'POST') return next();  // 세션에 wid 등록하는 요청은 pass
-		else if (!wid) res.send('잘못된 접근입니다.');  // 세션에 wid 없음: out
-		else if (refererPaths.every((e) => !ref.includes(e))) res.send('잘못된 접근입니다.');  // referer가 refererPaths에 포함되지 않음: out
-		else next();  // 모두 통과: ok
+		if (!id) res.render('Alert/needLogin');
+		else if (req.path === '/' && req.method === 'POST') return next();
+		else if (!wid) res.render('Alert/cannotAccess');
+		else if (!refererPaths.some((e) => (ref === e || ref === e + '/'))) res.render('Alert/cannotAccess');
+		else next();
 	};
 	router.use(check);
 

--- a/Routes/pv.js
+++ b/Routes/pv.js
@@ -4,6 +4,15 @@ module.exports = function(app,db){
 
     const pv_myWH = require('./pv_MyWH');
     const pv_EnrollWH = require('./pv_EnrollWH');
+
+    var check = (req, res, next) => {
+        var type = req.session['type'];
+        if (!type) res.render('Alert/needLogin');
+        else if (type === 'provider') next();
+        else res.render('Alert/cannotAccess');
+    };
+    router.use(check);
+
     router.get('/',function(req,res,next){
         res.render('User/Provider/pv_EnrollWH',{'app':app,'session':req.session,'db':db});
     });

--- a/Routes/user.js
+++ b/Routes/user.js
@@ -10,6 +10,15 @@ module.exports = function(app,db){
     const logout = require('./user_Logout');
     const emailIDF = require('./user_EmailIDF');
 
+    var check = (req, res, next) => {
+        const id = req.session['memberID'];
+        const path = req.path.toLowerCase();
+        const needLoginPath = ['/Logout', '/edit', '/edit/pw', '/show', '/delete'];
+        if (!id && needLoginPath.some((e) => (path === e || path === e + '/'))) res.render('Alert/cannotAccess');
+        else next();
+    };
+    router.use(check);
+
     router.post('/Register/MemberID',function(req,res,next){
         register.checkID(req,res,app,db);
     });

--- a/Views/Alert/cannotAccess.ejs
+++ b/Views/Alert/cannotAccess.ejs
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Autoinven</title>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+</head>
+<body>
+    <script>
+		Swal.fire({
+			title: 'Error',
+			text: 'Cannot access this page.',
+			icon: 'error'
+		}).then(() => history.back());
+    </script>
+</body>
+</html>

--- a/Views/Alert/needLogin.ejs
+++ b/Views/Alert/needLogin.ejs
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Autoinven</title>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+</head>
+<body>
+    <script>
+		Swal.fire({
+			title: 'Need to Login',
+			text: 'Cannot access this page without login.',
+			icon: 'warning'
+		}).then(() => location.href = '/User/Login');
+    </script>
+</body>
+</html>

--- a/Views/Iot/unauthorized.ejs
+++ b/Views/Iot/unauthorized.ejs
@@ -1,4 +1,0 @@
-<script>
-    alert('로그인 후 이용해주세요.');
-    location.href = 'login';
-</script>

--- a/webserver.js
+++ b/webserver.js
@@ -125,6 +125,8 @@ app.post('/RFID/Update',function(req,res){
   });
 });
 
+// 없는 페이지 alert 띄우기
+app.use((req, res, next) => { res.render('Alert/cannotAccess') });
 
 // 11) 서버를 열 때 설정 함수
 server.listen(5000,function(req,res){


### PR DESCRIPTION
Resolved: #10

## 개요
접근 불가능한 페이지에 alert 띄우기

## 작업사항
- 로그인 후 접근 가능한 페이지는 로그인 alert 띄운 후 로그인 페이지로 redirect
- member type이 다른 페이지에 접속하는 경우 alert 띄우고 뒤로 가기 (예: provider가 buyer 또는 admin 페이지에 접속)
- 존재하지 않는 페이지도 alert 띄우고 뒤로 가기

## 변경로직
### 변경전
- 로그인하지 않고 회원 정보 수정 페이지 등에 접속할 수 있음.
- provider가 창고 등록 요청 후 admin 페이지에 접속하여 본인의 요청을 수락할 수 있음.
- 없는 페이지의 경우 raw text로 render됨

### 변경후
- 접근 불가능한 경우 모두 alert를 띄우도록 수정, 경우에 따라 redirect 또는 back 수행

## 사용방법
접근 불가능한 페이지에 접속 후 확인
