### PR TITLE
fix: Admin RequestIOT Table Layout

### DIFF
--- a/Views/User/Admin/ad_RequestIoT.ejs
+++ b/Views/User/Admin/ad_RequestIoT.ejs
@@ -49,7 +49,7 @@
                     <th class="col-2">이름</th>
                     <th class="col-3">창고 주소</th>
                     <th class="col-1">국적</th>
-                    <th class="col-1"></th>
+                    <th class="col-2"></th>
                   </tr>
                 </thead>
                 <tbody>
@@ -62,7 +62,7 @@
                         <td class="col-2"><%= items['item'+i].name %></td>
                         <td class="col-3"><%= items['item'+i].address %></td>
                         <td class="col-1"><%= items['item'+i].national %></td>
-                        <td class="col-1" style="float:right; padding:0px 10px 0px 0px;">
+                        <td class="col-2" style="float:right; padding:0px 10px 0px 0px;">
                           <button type="button" class="btn btn-sm" onclick="adClick(<%=i%>, 1)">Approval</button>
                           <button type="button" class="btn btn-sm" onclick="adClick(<%=i%>, 0)">Cancel</button>
                         </td>


### PR DESCRIPTION
## 개요
Admin계정의 RequestIOT 페이지에서 table head가 잘리고, 승인/취소 버튼의 layout이 깨지는 것을 개선

### 변경전
table head가 짧음, button용 column의 크기가 작음

### 변경후
table head 길이 개선, button용 column의 크기 늘림


resolved: #65