### PR TITLE
Feat/127 rfid api

### DIFF
--- a/Routes/iot.js
+++ b/Routes/iot.js
@@ -8,19 +8,20 @@ module.exports = function (app, db) {
     const iot_registerItem = require('./iot_registerItem');
     const iot_editItem = require('./iot_editItem');
     const iot_help = require('./iot_help');
+    const iot_rfid = require('./iot_rfid');
 
     var check = (req, res, next) => {
         var id = req.session['memberID'];
-        var wid = req.session['warehouseID'];
-        // var hostIndex = (req.protocol + '://' + req.get('host')).length;
-        // var ref = req.headers.referer ? req.headers.referer.toLowerCase().substring(hostIndex) : '';
-        // const refererPaths = ['/provider/mywarehouse', '/buyer/usagestatus', '/admin/iottest', '/iot', '/iot/monitoring', '/iot/warehousing', '/iot/help', '/iot/registeritem', '/iot/statistics', '/iot/edititem', '/iot/editsave'];
-
-        if (!id) res.render('Alert/needLogin');
-        else if (req.path === '/' && req.method === 'POST') return next();
-        else if (!wid) res.render('Alert/cannotAccess');
-        // else if (!refererPaths.some((e) => (ref === e || ref === e + '/'))) res.render('Alert/cannotAccess');
-        else next();
+        if (req.path === '/rfid') {
+            if (!id) res.send('unauthorized');
+            else next();
+        } else {
+            var wid = req.session['warehouseID'];
+            if (!id) res.render('Alert/needLogin');
+            else if (req.path === '/' && req.method === 'POST') return next();
+            else if (!wid) res.render('Alert/cannotAccess');
+            else next();
+        }
     };
     router.use(check);
 
@@ -52,6 +53,8 @@ module.exports = function (app, db) {
     router.post('/editSave', (req, res, next) => {iot_editItem.editItem(req, res, db)});
 
     router.post('/deleteItem', (req, res, next) => {iot_warehousing.delItem(req, res, db) });
+
+    router.post('/rfid', (req, res, next) => { iot_rfid.receive(req, res, db) });
 
     return router;
 };

--- a/Routes/iot_rfid.js
+++ b/Routes/iot_rfid.js
@@ -1,0 +1,34 @@
+exports.receive = function (req, res, db) {
+    var mysql = require('mysql');
+    var connection = mysql.createConnection(require('../Module/db').info);
+    connection.connect();
+
+    var rfid = req.body.rfid;
+    var id = req.body.memberID;
+    connection.query('SELECT * FROM iot where rfid=?;', [rfid], (error, results, fields) => {
+        if (error) {
+            console.log("error: rfid 1", error);
+            res.send('error1');
+        } else if (results.length === 0) {
+            res.send('rfid not exist');
+        } else {
+            connection.query('SELECT * FROM provider, iot where provider.warehouseID = iot.warehouseID and iot.rfid=? and provider.memberID=?;', [rfid, id], (error, results, fields) => {
+                if (error) {
+                    console.log("error: rfid 2", error);
+                    res.send('error2');
+                } else if (results.length === 0) {
+                    res.send('unauthorized');
+                } else {
+                    connection.query('UPDATE iot SET received=1 WHERE rfid=?;', [rfid], (error, results, fields) => {
+                        if (error) {
+                            console.log("error: rfid 3", error);
+                            res.send('error3');
+                        } else {
+                            res.send('success');
+                        }
+                    });
+                }
+            });
+        }
+    });
+}

--- a/raspi/account.js
+++ b/raspi/account.js
@@ -1,0 +1,16 @@
+module.exports = () => {
+    var readline = require('readline');
+    return new Promise(resolve => {
+        var r1 = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout
+        });
+        r1.question('ID: ', (id) => {
+            r1.question('Password: ', (pw) => {
+                r1.close();
+                console.clear();
+                resolve({id, pw});
+            });
+        });
+    })
+}

--- a/raspi/apollo.js
+++ b/raspi/apollo.js
@@ -1,0 +1,36 @@
+var posts = require('./posts');
+var SerialPort = require('serialport');
+var Readline = require('@serialport/parser-readline');
+var {ApolloServer, gql, PubSub} = require("apollo-server");
+
+module.exports = (fdata) => {
+    var pubsub = new PubSub();
+    // var serial = new SerialPort('/COM5', 9600);  // windows
+    var serial = new SerialPort('/dev/ttyACM0', 9600);  // raspi
+    var parser = serial.pipe(new Readline({delimiter: '\r\n'}));
+
+    var typeDefs = gql`
+	  type Query {
+		_: String
+	  }
+	  type Subscription {
+		value: String
+	  }
+	`;
+    var resolvers = {
+        Subscription: {
+            value: {
+                subscribe: () => pubsub.asyncIterator("monitoring")
+            },
+        },
+    };
+
+    parser.on('data', (data) => {
+        var rfid = data.substring(0, 8);
+        var monitoringData = data.substr(9);
+        pubsub.publish("monitoring", {value: monitoringData});
+        if (rfid !== 'FFFFFFFF') posts.sendrfid(rfid, fdata, posts.login);
+    });
+
+    return new ApolloServer({ typeDefs, resolvers }, playground = true);
+}

--- a/raspi/app.js
+++ b/raspi/app.js
@@ -1,0 +1,20 @@
+var request = require('request');
+var account = require('./account');
+var apollo = require('./apollo');
+var posts = require('./posts');
+
+(async () => {
+    var acc = await account();
+    var fdata = {
+        id: acc.id,
+        pw: acc.pw,
+        ip: '192.168.0.54:5000',  // autoinven.com
+        jar: request.jar()
+    }
+    posts.login(fdata, () => {
+        var apolloServer = apollo(fdata);
+        apolloServer.listen({port: 3000}).then(({url}) => {
+            console.log(`Listening at ${url}\n`);
+        });
+    });
+})();

--- a/raspi/posts.js
+++ b/raspi/posts.js
@@ -1,0 +1,35 @@
+var request = require('request');
+
+exports.login = (fdata, callback) => {
+    request.post({
+        url: `http://${fdata.ip}/User/Login`,
+        body: {memberID: fdata.id, password: fdata.pw},
+        json: true,
+        jar: fdata.jar
+    }, (error, response, body) => {
+        if (body === 'loginSuccess') callback();
+        else if (body === 'loginError01') console.log('login: id error');
+        else if (body === 'loginError02') console.log('login: pw error');
+        else if (!body) console.log(`unable to connect: ${fdata.ip}`);
+        else console.log(`login error: ${body}\n`);
+    });
+}
+
+exports.sendrfid = (rfid, fdata, callback) => {
+    request.post({
+        url: `http://${fdata.ip}/iot/rfid`,
+        body: {memberID: fdata.id, rfid: rfid},
+        json: true,
+        jar: fdata.jar
+    }, (error, response, body) => {
+        if (body === 'success') {
+            console.log(`rfid ${rfid}: success`);
+        } else if (body === 'unauthorized') {
+            console.log(`rfid ${rfid}: need to login`);
+            callback(fdata, () => {});
+            module.exports.sendrfid(rfid, fdata, callback);
+        } else if (body === 'rfid not exist') {
+            console.log(`rfid ${rfid}: ${body}`);
+        }
+    });
+}


### PR DESCRIPTION
## 개요
라즈베리파이에서 rfid 태그를 수신하였을 때, 서버 측으로 post를 날려 db 쿼리문을 수행하도록 하는 api 구현

## 작업사항
- 라즈베리파이
  - 메인 서버에 로그인
  - 1초마다 센서 값 측정
  - rfid 태그가 ffffffff가 아닌 경우 메인 서버로 post 전송
  - graphql 웹소켓 서버 생성
  -  로그인 이후 서버가 재시작되면 로그아웃 처리됨, 이에 대한 예외처리 구현
- 메인 서버
  - 라즈베리파이를 위한 rfid api 구현

## 사용방법
1. 라즈베리파이에 아두이노 연결
2. app.js 내 올바른 메인 서버 url 입력
3. app.js 실행
4. 콘솔에서 로그인
5. rfid 태그를 읽히면 메인 서버에서 db update를 수행함.


resolved: #127 