### PR TITLE
Feature/135 wh enroll req

### DIFF
--- a/Public/JS/enrollWH.js
+++ b/Public/JS/enrollWH.js
@@ -13,6 +13,7 @@
             var addressDetail = $("#addressDetail").val();
             var landArea = $("#landArea").val();
             var floorArea = $("#floorArea").val();
+            var useableArea = $("#useableArea").val();
             var price = $("#price").val();
             var infoComment = $("#infoComment").val();
             var etcComment = $("#etcComment").val();
@@ -71,6 +72,12 @@
                     title: 'Fail',
                     text: "You have to insert your warehouse floor area"
                 })
+            } else if (!useableArea) {
+                Swal.fire({
+                    icon: 'error',
+                    title: 'Fail',
+                    text: "You have to insert your warehouse usable area"
+                })
             } else if (!price) {
                 Swal.fire({
                     icon: 'error',
@@ -99,14 +106,14 @@
                             Swal.fire({
                                 icon: 'error',
                                 title: 'Fail',
-                                text: 'Please enter only numbers in the landArea field.',
+                                text: 'Please enter only numbers in the Land Area field.',
                             }).then(() => {
                             })
                         } else if (data == "errortype3") {
                             Swal.fire({
                                 icon: 'error',
                                 title: 'Fail',
-                                text: 'Please enter only numbers in the floorArea field.',
+                                text: 'Please enter only numbers in the Floor Area field.',
                             }).then(() => {
                             })
                         } else if (data == "errortype4") {
@@ -157,6 +164,14 @@
                                 title: 'Fail',
                                 text: 'Please enter the telephone number in the correct format.',
                             }).then(() => {
+                            })
+                        } else if (data == "errortype11") {
+                            Swal.fire({
+                                icon: 'error',
+                                title: 'fail',
+                                text: 'Please enter only numbers in the Useable Area field.',
+                            }).then(() => {
+                                location.href = "/";
                             })
                         } else if (data == "errortype0") {
                             Swal.fire({

--- a/Public/JS/enrollWH.js
+++ b/Public/JS/enrollWH.js
@@ -10,6 +10,7 @@
             var whEmail = $("#warehouseEmail").val();
             var whTel = $("#warehouseTel").val();
             var address = $("#address").val();
+            var addressDetail = $("#addressDetail").val();
             var landArea = $("#landArea").val();
             var floorArea = $("#floorArea").val();
             var price = $("#price").val();
@@ -41,12 +42,20 @@
                     text: 'You have to insert your warehouse contact telephone number'
                 })
             }
-            //check password is not null
+            //check address is not null
             else if (!address) {
                 Swal.fire({
                     icon: 'error',
                     title: 'Fail',
                     text: 'You have to insert your warehouse address'
+                })
+            }
+            //check addressDetail is not null
+            else if (!addressDetail) {
+                Swal.fire({
+                    icon: 'error',
+                    title: 'Fail',
+                    text: 'You have to insert your warehouse detail address'
                 })
             }
             //check email is not null

--- a/Public/JS/findWH.js
+++ b/Public/JS/findWH.js
@@ -42,12 +42,24 @@ function initMap() {
             $("#whID").html(items[k]['warehouseID']);
             $("#whName").html(items[k]['warehouseName']);
             $("#whAddress").html(items[k]['address']);
-            $("#whFloorArea").html(items[k]['floorArea']);
-            $("#whUseableArea").html(items[k]['useableArea']);
+            $("#whAddressDetail").html(items[k]['addressDetail']);
+            $("#whLandArea").html(items[k]['landArea'] + " m<sup>2</sup>");
+            $("#whFloorArea").html(items[k]['floorArea'] + " m<sup>2</sup>");
+            $("#whUseableArea").html(items[k]['useableArea'] + " m<sup>2</sup>");
             $("#whEmail").html(items[k]['warehouseEmail']);
             $("#whPhone").html(items[k]['warehouseTel']);
-            $("#whPrice").html(items[k]['price']);
+            $("#whPrice").html(items[k]['price'] + " $");
+            if (items[k]['iotStat'] === 'Y') {
+                $("#whIoT").html("In Use");
+            } else if (items[k]['iotStat'] === 'w') {
+                $("#whIoT").html("Pending Approval");
+            } else if (items[k]['iotStat'] === 'N') {
+                $("#whIoT").html("Not Currently Used");
+            } else {
+                $("#whIoT").html("Error");
+            }
             $("#whInfoComment").html(items[k]['infoComment']);
+            $("#whEtcComment").html(items[k]['etcComment']);
         });
         i++;
     }

--- a/Routes/by_FindWH.js
+++ b/Routes/by_FindWH.js
@@ -10,6 +10,7 @@ exports.findWH = function (req, res, app, db) {
                 warehouseTel: results[step].warehouseTEL,
                 enrolledDate: results[step].enrolledDate,
                 address: results[step].address,
+                addressDetail: results[step].addressDetail,
                 latitude: results[step].latitude,
                 longitude: results[step].longitude,
                 landArea: results[step].landArea,

--- a/Routes/pv_EnrollWH.js
+++ b/Routes/pv_EnrollWH.js
@@ -13,6 +13,7 @@ exports.EnrollWH = function (req, res, app, db) {
         enrolledDate: new Date(),
         zipcode: req.body.zipcode,
         address: req.body.address,
+        addressDetail: req.body.addressDetail,
         latitude: req.body.lat,
         longitude: req.body.lng,
         landArea: req.body.landArea,

--- a/Routes/pv_EnrollWH.js
+++ b/Routes/pv_EnrollWH.js
@@ -18,7 +18,7 @@ exports.EnrollWH = function (req, res, app, db) {
         longitude: req.body.lng,
         landArea: req.body.landArea,
         floorArea: req.body.floorArea,
-        useableArea: req.body.floorArea,
+        useableArea: req.body.useableArea,
         price: req.body.price,
         infoComment: req.body.infoComment,
         etcComment: req.body.etcComment,
@@ -32,6 +32,9 @@ exports.EnrollWH = function (req, res, app, db) {
     } else if (onlyNum.test(item.floorArea) == false) {
         res.send("errortype3");
         console.log('errortype3');
+    } else if (onlyNum.test(item.useableArea) == false) {
+        res.send("errortype11");
+        console.log('errortype11');
     } else if (onlyNum.test(item.price) == false) {
         res.send("errortype4");
         console.log('errortype4');

--- a/Views/User/Admin/ad_RequestEnroll.ejs
+++ b/Views/User/Admin/ad_RequestEnroll.ejs
@@ -26,18 +26,7 @@
       <div class="container mb-3">
 
         <h2 class="mb-3">Submit Lists</h2>
-        <% for(var i = 0; i < Object.keys(items).length; i++) { %>
-          <p id="whID<%= i %>" style="display: none"><%= items['item' + i].warehouseID %></p>
-          <p id="reqType<%= i %>" style="display: none"><%= items['item' + i].reqType %></p>
-          <p id="reqID<%= i %>" style="display: none"><%= items['item' + i].reqID %></p>
-          <p id="providerID<%= i %>" style="display: none"><%= items['item' + i].providerID %></p>
-          <p id="floorArea<%= i %>" style="display: none"><%= items['item' + i].floorArea %></p>
-          <p id="national<%= i %>" style="display: none"><%= items['item' + i].national %></p>
-          <p id="name<%= i %>" style="display: none"><%= items['item' + i].name %></p>
-          <p id="address<%= i %>" style="display: none"><%= items['item' + i].address %></p>
-
-        <% } %>
-        <div class="table-responsive">
+         <div class="table-responsive">
           <table class="board-table table ">
             <thead class="thead-dark">
             <tr class="d-flex">
@@ -55,17 +44,18 @@
             <% for(var i = 0; i < Object.keys(items).length; i++) { %>
               <% if(items['item' + i].reqType == "ReqEnrollPV"){ %>
                 <tr class="table-warning d-flex">
-                  <td class="col-1"><%= items['item' + i].warehouseID %></td>
-                  <td class="col-1">Pending Approval</td>
-                  <td class="col-1"><%= items['item' + i].floorArea %></td>
-                  <td class="col-2"><%= items['item' + i].providerID %></td>
-                  <td class="col-2"><%= items['item' + i].name %></td>
-                  <td class="col-3"><%= items['item' + i].address %></td>
-                  <td class="col-1"><%= items['item' + i].national %></td>
+                  <td id="whID<%= i %>" class="col-1"><%= items['item' + i].warehouseID %></td>
+                  <td id="reqType<%= i %>" class="col-1">Pending Approval</td>
+                  <td id="floorArea<%= i %>"  class="col-1"><%= items['item' + i].floorArea %></td>
+                  <td id="providerID<%= i %>" class="col-2"><%= items['item' + i].providerID %></td>
+                  <td id="name<%= i %>" class="col-2"><%= items['item' + i].name %></td>
+                  <td id="address<%= i %>" class="col-3"><%= items['item' + i].address %></td>
+                  <td id="national<%= i %>" class="col-1"><%= items['item' + i].national %></td>
                   <td class="col-1" style="float:right; padding:0px 10px 0px 0px;">
                     <button type="button" class="btn btn-sm" onclick="adClick(<%= i %>, 1)">Approve</button>
                     <button type="button" class="btn btn-sm" onclick="adClick(<%= i %>, 0)">Cancel</button>
-                  </td>
+                  </td>                  
+                  <p id="reqID<%= i %>" style="display: none"><%= items['item' + i].reqID %></p>
                 </tr>
               <% } %>
             <% } %>

--- a/Views/User/Admin/ad_RequestEnroll.ejs
+++ b/Views/User/Admin/ad_RequestEnroll.ejs
@@ -24,7 +24,6 @@
         <h1>Enroll Request List</h1>
       </div>
       <div class="container mb-3">
-
         <h2 class="mb-3">Submit Lists</h2>
          <div class="table-responsive">
           <table class="board-table table ">

--- a/Views/User/Buyer/by_FindWH.ejs
+++ b/Views/User/Buyer/by_FindWH.ejs
@@ -24,23 +24,30 @@
           </div>
           <tbody>
           <tr>
-            <th class="thead-dark-vertical">Warehouse Name</thclass=thead-dark-vertical>
+            <th class="thead-dark-vertical">Name</thclass=thead-dark-vertical>
             <td id="whName"></td>
           </tr>
           <tr>
-            <th class="thead-dark-vertical">Address</th>
-            <td id="whAddress"></td>
+            <th rowspan="2" class="thead-dark-vertical">Address</th>
+            <td id="whAddress">　</td>
+          </tr>
+          <tr>
+            <td id="whAddressDetail">　</td>
+          </tr>
+          <tr>
+            <th class="thead-dark-vertical">Land Area</th>
+            <td id="whLandArea"></td>
           </tr>
           <tr>
             <th class="thead-dark-vertical">Floor Area</th>
-            <td id="whFloorArea"> m<sup>2</sup></td>
+            <td id="whFloorArea"></td>
           </tr>
           <tr>
             <th class="thead-dark-vertical">Usable Area</th>
-            <td id="whUseableArea"> m<sup>2</sup></td>
+            <td id="whUseableArea"></td>
           </tr>
           <tr>
-            <th class="thead-dark-vertical">Price Per Area</th>
+            <th class="thead-dark-vertical">Price Per m<sup>2</sup></th>
             <td id="whPrice"></td>
           </tr>
           <tr>
@@ -52,9 +59,17 @@
             <td id="whPhone"></td>
           </tr>
           <tr>
+            <th class="thead-dark-vertical">IoT</th>
+            <td id="whIoT"></td>
+          </tr>
+          <tr>
             <th class="thead-dark-vertical">Comment</th>
             <td id=whInfoComment></td>
             <td id="whID" style="display: none"></td>
+          </tr>
+          <tr>
+            <th class="thead-dark-vertical">ETC</th>
+            <td id=whEtcComment></td>
           </tr>
           </tbody>
         </table>

--- a/Views/User/Provider/pv_EnrollWH.ejs
+++ b/Views/User/Provider/pv_EnrollWH.ejs
@@ -49,12 +49,16 @@
         <div class="col-sm-4"><input type="text" class="form-control" id="warehouseTel" name="warehouseTel" placeholder="Telephone Number (ex. 010-0000-0000)"></div>
       </div>
       <div class="form-group row">
-        <label class="col-sm-2 col-form-label">LandArea</label>
+        <label class="col-sm-2 col-form-label">Land Area</label>
         <div class="col-sm-2"><input type="text" class="form-control" id="landArea" name="landArea" placeholder="Numbers Only"></div>
       </div>
       <div class="form-group row">
-        <label class="col-sm-2 col-form-label">FloorArea</label>
+        <label class="col-sm-2 col-form-label">Floor Area</label>
         <div class="col-sm-2"><input type="text" class="form-control" id="floorArea" name="floorArea" placeholder="Numbers Only"></div>
+      </div>
+      <div class="form-group row">
+        <label class="col-sm-2 col-form-label">Useable Area</label>
+        <div class="col-sm-2"><input type="text" class="form-control" id="useableArea" name="useableArea" placeholder="Numbers Only"></div>
       </div>
       <div class="form-group row">
         <label class="col-sm-2 col-form-label">Price Per Area</label>

--- a/Views/User/Provider/pv_EnrollWH.ejs
+++ b/Views/User/Provider/pv_EnrollWH.ejs
@@ -35,6 +35,12 @@
         </div>
       </div>
       <div class="form-group row">
+        <label class="col-sm-2 col-form-label"></label>
+        <div class="col-sm-8">
+          <input type="text" class="form-control" id="addressDetail" name="addressDetail" placeholder="Detail Address (ex. 3rd Floor)">
+        </div>
+      </div>
+      <div class="form-group row">
         <label class="col-sm-2 col-form-label">Warehouse Email</label>
         <div class="col-sm-3"><input type="text" class="form-control" id="warehouseEmail" name="warehouseEmail" placeholder="Contact Email"></div>
       </div>


### PR DESCRIPTION
## 개요
창고 등록과 신청시 사용성 개선
## 작업사항
- [x] 창고 등록시 상세 주소 입력 칸 추가 및 동작 구현
- [x] 창고 신청시 상세 주소 조회 칸 추가
- [x] 창고 신청시 IoT 사용여부 확인 칸 추가
- [x] 창고 등록시 사용가능 공간 입력하도록 추가
- [x] 창고 신청시 3가지 종류의 공간이 모두 보이도록 수정
- [x] 창고 신청시 코멘트가 모두 보이게 수정
- [x] Admin에서 Request Enroll 페이지의 코드 리팩토링
## 변경로직
### 변경전
추가적인 정보 입력 칸이 없고 데이터가 보이지 않음
### 변경후
- 상세 데이터가 좀 더 보이도록 하여 사용자의 편의 개선
- 추가적으로 필요한 정보를 입력할 수 있는 필드 만듦
## 사용방법
Provider와 Buyer 계정으로 로그인하여 각자 창고 등록, 창고 검색 확인
## 기타


resolved: #135 