### PR TITLE
Feature/220 show request

### DIFF
--- a/Routes/RequestWHInfo.js
+++ b/Routes/RequestWHInfo.js
@@ -1,0 +1,34 @@
+const viewInfo = require('./viewInfo');
+
+exports.getWHInfo = function (req, res, app, db) {
+    var reqID = req.body.reqID;
+    var items = {};
+    let results = db.query(`select warehouseID from RequestForBuy where reqID=` + reqID + `;`);
+    if (results.length > 0) {
+        var warehouseID = results[0].warehouseID;
+        items = viewInfo.getWHInfo(db, warehouseID);
+    }
+    return items;
+}
+
+exports.getPVInfo = function (req, res, app, db) {
+    var reqID = req.body.reqID;
+    var items = {};
+    let results = db.query(`select memberID from RequestForBuy, Provider where RequestForBuy.warehouseID=Provider.warehouseID and RequestForBuy.reqID=` + reqID + `;`);
+    if (results.length > 0) {
+        var providerID = results[0].memberID;
+        items = viewInfo.getMemberInfo(db, providerID);
+    }
+    return items;
+}
+
+exports.getBYInfo = function (req, res, app, db) {
+    var reqID = req.body.reqID;
+    var items = {};
+    let results = db.query(`select buyerID from RequestForBuy where reqID=` + reqID + `;`);
+    if (results.length > 0) {
+        var buyerID = results[0].buyerID;
+        items = viewInfo.getMemberInfo(db, buyerID);
+    }
+    return items;
+}

--- a/Routes/RequestWHInfo.js
+++ b/Routes/RequestWHInfo.js
@@ -32,3 +32,22 @@ exports.getBYInfo = function (req, res, app, db) {
     }
     return items;
 }
+
+exports.getReqInfo = function (req, res, app, db) {
+    var reqID = req.body.reqID;
+    var items = {};
+    let results = db.query(`select * from RequestForBuy, Warehouse where Warehouse.warehouseID=RequestForBuy.warehouseID and reqID=` + reqID + `;`);
+    if (results.length > 0) {
+        items = {
+            reqID: results[0].reqID,
+            reqDate: results[0].reqDate.substring(0, 10),
+            warehouseID: results[0].warehouseID,
+            buyerID: results[0].buyerID,
+            amounts: results[0].price * results[0].area,
+            startDate: results[0].startDate.substring(0, 10),
+            endDate: results[0].endDate.substring(0, 10),
+            area: results[0].area
+        };
+    }
+    return JSON.stringify(items);
+}

--- a/Routes/ad.js
+++ b/Routes/ad.js
@@ -62,10 +62,12 @@ module.exports = function (app, db) {
         var WHitems = RequestWHInfo.getWHInfo(req, res, app, db);
         var PVitems = RequestWHInfo.getPVInfo(req, res, app, db);
         var BYitems = RequestWHInfo.getBYInfo(req, res, app, db);
+        var ReqItems = RequestWHInfo.getReqInfo(req, res, app, db);
         WHitems = JSON.parse(WHitems);
         PVitems = JSON.parse(PVitems);
         BYitems = JSON.parse(BYitems);
-        res.render('User/RequestWHInfo', {'req': req, 'app': app, 'session': req.session, 'db': db, 'WHitems': WHitems, 'PVitems': PVitems, 'BYitems': BYitems});
+        ReqItems = JSON.parse(ReqItems);
+        res.render('User/RequestWHInfo', {'req': req, 'app': app, 'session': req.session, 'db': db, 'WHitems': WHitems, 'PVitems': PVitems, 'BYitems': BYitems, 'ReqItems': ReqItems});
     });
 
     router.get('/WarehouseList', function (req, res, next) {

--- a/Routes/ad.js
+++ b/Routes/ad.js
@@ -61,7 +61,7 @@ module.exports = function (app, db) {
     router.post('/RequestWHInfo', function (req, res, next) {
         var WHitems = RequestWHInfo.getWHInfo(req, res, app, db);
         var PVitems = RequestWHInfo.getPVInfo(req, res, app, db);
-        var BYitems = RequestWHInfo.getPVInfo(req, res, app, db);
+        var BYitems = RequestWHInfo.getBYInfo(req, res, app, db);
         WHitems = JSON.parse(WHitems);
         PVitems = JSON.parse(PVitems);
         BYitems = JSON.parse(BYitems);

--- a/Routes/ad.js
+++ b/Routes/ad.js
@@ -10,6 +10,7 @@ module.exports = function (app, db) {
     const ad_WarehouseList = require('./ad_WarehouseList');
     const WHInfo = require('./WHInfo');
     const EnrollWHInfo = require('./EnrollWHInfo');
+    const RequestWHInfo = require('./RequestWHInfo');
 
     var check = (req, res, next) => {
         var type = req.session['type'];
@@ -55,6 +56,16 @@ module.exports = function (app, db) {
         var items = ad_ReqBuy.RequestForBuy(req, res, app, db);
         items = JSON.parse(items);
         res.render('User/Admin/ad_RequestBuy', {'app': app, 'session': req.session, 'db': db, 'items': items});
+    });
+
+    router.post('/RequestWHInfo', function (req, res, next) {
+        var WHitems = RequestWHInfo.getWHInfo(req, res, app, db);
+        var PVitems = RequestWHInfo.getPVInfo(req, res, app, db);
+        var BYitems = RequestWHInfo.getPVInfo(req, res, app, db);
+        WHitems = JSON.parse(WHitems);
+        PVitems = JSON.parse(PVitems);
+        BYitems = JSON.parse(BYitems);
+        res.render('User/RequestWHInfo', {'req': req, 'app': app, 'session': req.session, 'db': db, 'WHitems': WHitems, 'PVitems': PVitems, 'BYitems': BYitems});
     });
 
     router.get('/WarehouseList', function (req, res, next) {

--- a/Routes/by.js
+++ b/Routes/by.js
@@ -42,9 +42,11 @@ module.exports = function (app, db) {
     router.post('/RequestWHInfo', function (req, res, next) {
         var WHitems = RequestWHInfo.getWHInfo(req, res, app, db);
         var PVitems = RequestWHInfo.getPVInfo(req, res, app, db);
+        var ReqItems = RequestWHInfo.getReqInfo(req, res, app, db);
         WHitems = JSON.parse(WHitems);
         PVitems = JSON.parse(PVitems);
-        res.render('User/RequestWHInfo', {'req': req, 'app': app, 'session': req.session, 'db': db, 'WHitems': WHitems, 'PVitems': PVitems});
+        ReqItems = JSON.parse(ReqItems);
+        res.render('User/RequestWHInfo', {'req': req, 'app': app, 'session': req.session, 'db': db, 'WHitems': WHitems, 'PVitems': PVitems, 'ReqItems': ReqItems});
     });
 
     router.get('/UsageHistory', function (req, res, next) {

--- a/Routes/by.js
+++ b/Routes/by.js
@@ -5,6 +5,7 @@ module.exports = function (app, db) {
     var requestWH = require('./by_RequestStatus');
     var UsageHistory = require('./by_UsageHistory');
     var UsageHistoryInfo = require('./by_UsageHistoryInfo');
+    const RequestWHInfo = require('./RequestWHInfo');
 
     var check = (req, res, next) => {
         var type = req.session['type'];
@@ -36,6 +37,14 @@ module.exports = function (app, db) {
         var items = requestWH.RequestForBuy(req, res, app, db);
         items = JSON.parse(items);
         res.render('User/Buyer/by_RequestStatus', {'app': app, 'session': req.session, 'db': db, 'items': items});
+    });
+    
+    router.post('/RequestWHInfo', function (req, res, next) {
+        var WHitems = RequestWHInfo.getWHInfo(req, res, app, db);
+        var PVitems = RequestWHInfo.getPVInfo(req, res, app, db);
+        WHitems = JSON.parse(WHitems);
+        PVitems = JSON.parse(PVitems);
+        res.render('User/RequestWHInfo', {'req': req, 'app': app, 'session': req.session, 'db': db, 'WHitems': WHitems, 'PVitems': PVitems});
     });
 
     router.get('/UsageHistory', function (req, res, next) {

--- a/Routes/pv.js
+++ b/Routes/pv.js
@@ -80,9 +80,11 @@ module.exports = function (app, db) {
     router.post('/RequestWHInfo', function (req, res, next) {
         var WHitems = RequestWHInfo.getWHInfo(req, res, app, db);
         var BYitems = RequestWHInfo.getBYInfo(req, res, app, db);
+        var ReqItems = RequestWHInfo.getReqInfo(req, res, app, db);
         WHitems = JSON.parse(WHitems);
         BYitems = JSON.parse(BYitems);
-        res.render('User/RequestWHInfo', {'req': req, 'app': app, 'session': req.session, 'db': db, 'WHitems': WHitems, 'BYitems': BYitems});
+        ReqItems = JSON.parse(ReqItems);
+        res.render('User/RequestWHInfo', {'req': req, 'app': app, 'session': req.session, 'db': db, 'WHitems': WHitems, 'BYitems': BYitems, 'ReqItems': ReqItems});
     });
 
     router.get('/MyWarehouse', function (req, res, next) {

--- a/Routes/pv.js
+++ b/Routes/pv.js
@@ -79,7 +79,7 @@ module.exports = function (app, db) {
     
     router.post('/RequestWHInfo', function (req, res, next) {
         var WHitems = RequestWHInfo.getWHInfo(req, res, app, db);
-        var BYitems = RequestWHInfo.getPVInfo(req, res, app, db);
+        var BYitems = RequestWHInfo.getBYInfo(req, res, app, db);
         WHitems = JSON.parse(WHitems);
         BYitems = JSON.parse(BYitems);
         res.render('User/RequestWHInfo', {'req': req, 'app': app, 'session': req.session, 'db': db, 'WHitems': WHitems, 'BYitems': BYitems});

--- a/Routes/pv.js
+++ b/Routes/pv.js
@@ -76,7 +76,6 @@ module.exports = function (app, db) {
         WHitems = JSON.parse(WHitems);
         res.render('User/EnrollWHInfo', {'req': req, 'app': app, 'session': req.session, 'db': db, 'WHitems': WHitems});
     });
-
     
     router.post('/RequestWHInfo', function (req, res, next) {
         var WHitems = RequestWHInfo.getWHInfo(req, res, app, db);

--- a/Routes/pv.js
+++ b/Routes/pv.js
@@ -7,6 +7,7 @@ module.exports = function (app, db) {
     const WHInfo = require('./WHInfo');
     const WHEdit = require('./WHEdit');    
     const EnrollWHInfo = require('./EnrollWHInfo');
+    const RequestWHInfo = require('./RequestWHInfo');
 
     var check = (req, res, next) => {
         var type = req.session['type'];
@@ -74,6 +75,15 @@ module.exports = function (app, db) {
         var WHitems = EnrollWHInfo.getWHInfo(req, res, app, db);
         WHitems = JSON.parse(WHitems);
         res.render('User/EnrollWHInfo', {'req': req, 'app': app, 'session': req.session, 'db': db, 'WHitems': WHitems});
+    });
+
+    
+    router.post('/RequestWHInfo', function (req, res, next) {
+        var WHitems = RequestWHInfo.getWHInfo(req, res, app, db);
+        var BYitems = RequestWHInfo.getPVInfo(req, res, app, db);
+        WHitems = JSON.parse(WHitems);
+        BYitems = JSON.parse(BYitems);
+        res.render('User/RequestWHInfo', {'req': req, 'app': app, 'session': req.session, 'db': db, 'WHitems': WHitems, 'BYitems': BYitems});
     });
 
     router.get('/MyWarehouse', function (req, res, next) {

--- a/Views/User/Admin/ad_RequestBuy.ejs
+++ b/Views/User/Admin/ad_RequestBuy.ejs
@@ -19,10 +19,12 @@
         <table class="board-table table ">
           <thead class="thead-dark">
             <tr>
+              <th>Req ID</th>
               <th>Warehouse ID</th>
+              <th>Buyer ID</th>
               <th>State</th>
-              <th>Rental Fee($)</th>
               <th>Rental Period</th>
+              <th>Info</th>
               <th></th>
               <th></th>
             </tr>
@@ -33,40 +35,68 @@
 
               <% if (items['item' + i].reqType === 'ReqByBuyer') { %>
             <tr class="table-warning">
+              <td><%= items['item' + i].reqID %></td>
               <td><%= items['item' + i].warehouseID %></td>
+              <td><%= items['item' + i].buyerID %></td>
               <td>Pending Approval</td>
-              <td><%= items['item' + i].amounts %></td>
               <td><%= items['item' + i].startDate %> ~ <%= items['item' + i].endDate %></td>
+              <td id="td-btn">
+                <form action="/Admin/RequestWHInfo" method="POST">
+                  <input id="reqID" name="reqID" type="hidden" value="<%= items['item' + i].reqID %>">
+                  <button class="btn btn-td btn-info">INFO</button>
+                </form>
+              </td>
               <td id="td-btn"><button type="button" class="btn btn-td btn-success" onclick="adClick(<%= i %>, 1)">Approve</button></td>
               <td id="td-btn"><button type="button" class="btn btn-td btn-danger" onclick="adClick(<%= i %>, 0)">Reject</button></td>
             </tr>
 
             <% } else if (['ReqByAdmin', 'ReqByPv'].includes(items['item' + i].reqType)) { %>
             <tr class="table-basic">
+              <td><%= items['item' + i].reqID %></td>
               <td><%= items['item' + i].warehouseID %></td>
+              <td><%= items['item' + i].buyerID %></td>
               <td>In Progress</td>
-              <td><%= items['item' + i].amounts %></td>
               <td><%= items['item' + i].startDate %> ~ <%= items['item' + i].endDate %></td>
+              <td id="td-btn">
+                <form action="/Admin/RequestWHInfo" method="POST">
+                  <input id="reqID" name="reqID" type="hidden" value="<%= items['item' + i].reqID %>">
+                  <button class="btn btn-td btn-info">INFO</button>
+                </form>
+              </td>
               <td></td>
               <td></td>
             </tr>
 
             <% } else if (items['item' + i].reqType.includes('RejByPv')) { %>
             <tr class="table-danger">
+              <td><%= items['item' + i].reqID %></td>
               <td><%= items['item' + i].warehouseID %></td>
+              <td><%= items['item' + i].buyerID %></td>
               <td>Rejected By Provider</td>
-              <td><%= items['item' + i].amounts %></td>
               <td><%= items['item' + i].startDate %> ~ <%= items['item' + i].endDate %></td>
+              <td id="td-btn">
+                <form action="/Admin/RequestWHInfo" method="POST">
+                  <input id="reqID" name="reqID" type="hidden" value="<%= items['item' + i].reqID %>">
+                  <button class="btn btn-td btn-info">INFO</button>
+                </form>
+              </td>
               <td></td>
               <td id="td-btn"><button type="button" class="btn btn-td btn-info" onclick="adClick(<%= i %>, 2)">View</button></td>
             </tr>
 
             <% } else if (items['item' + i].reqType.includes('CnlByBuyer')) { %>
             <tr class="table-danger">
+              <td><%= items['item' + i].reqID %></td>
               <td><%= items['item' + i].warehouseID %></td>
+              <td><%= items['item' + i].buyerID %></td>
               <td>Canceled By Buyer</td>
-              <td><%= items['item' + i].amounts %></td>
               <td><%= items['item' + i].startDate %> ~ <%= items['item' + i].endDate %></td>
+              <td id="td-btn">
+                <form action="/Admin/RequestWHInfo" method="POST">
+                  <input id="reqID" name="reqID" type="hidden" value="<%= items['item' + i].reqID %>">
+                  <button class="btn btn-td btn-info">INFO</button>
+                </form>
+              </td>
               <td></td>
               <td id="td-btn"><button type="button" class="btn btn-td btn-info" onclick="adClick(<%= i %>, 2)">View</button></td>
             </tr>

--- a/Views/User/Admin/ad_RequestBuy.ejs
+++ b/Views/User/Admin/ad_RequestBuy.ejs
@@ -26,7 +26,6 @@
               <th>Rental Period</th>
               <th>Info</th>
               <th></th>
-              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -46,8 +45,10 @@
                   <button class="btn btn-td btn-info">INFO</button>
                 </form>
               </td>
-              <td id="td-btn"><button type="button" class="btn btn-td btn-success" onclick="adClick(<%= i %>, 1)">Approve</button></td>
-              <td id="td-btn"><button type="button" class="btn btn-td btn-danger" onclick="adClick(<%= i %>, 0)">Reject</button></td>
+              <td id="td-btn">
+                <button type="button" class="btn btn-td btn-success" onclick="adClick(<%= i %>, 1)">Approve</button>
+                <button type="button" class="btn btn-td btn-danger" onclick="adClick(<%= i %>, 0)">Reject</button>
+              </td>
             </tr>
 
             <% } else if (['ReqByAdmin', 'ReqByPv'].includes(items['item' + i].reqType)) { %>
@@ -64,7 +65,6 @@
                 </form>
               </td>
               <td></td>
-              <td></td>
             </tr>
 
             <% } else if (items['item' + i].reqType.includes('RejByPv')) { %>
@@ -80,7 +80,6 @@
                   <button class="btn btn-td btn-info">INFO</button>
                 </form>
               </td>
-              <td></td>
               <td id="td-btn"><button type="button" class="btn btn-td btn-info" onclick="adClick(<%= i %>, 2)">View</button></td>
             </tr>
 
@@ -97,7 +96,6 @@
                   <button class="btn btn-td btn-info">INFO</button>
                 </form>
               </td>
-              <td></td>
               <td id="td-btn"><button type="button" class="btn btn-td btn-info" onclick="adClick(<%= i %>, 2)">View</button></td>
             </tr>
             <% } %>

--- a/Views/User/Admin/ad_RequestEnroll.ejs
+++ b/Views/User/Admin/ad_RequestEnroll.ejs
@@ -56,7 +56,14 @@
                 <td id="whID<%= i %>"><%= items['item' + i].warehouseID %></td>    
                 <td id="name<%= i %>"><%= items['item' + i].warehouseName %></td>          
                 <td id="providerID<%= i %>"><%= items['item' + i].providerID %></td>
-                <td id="reqType<%= i %>">Canceled by Provider</td>   
+                <td id="reqType<%= i %>">Canceled by Provider</td>
+                <td id="td-btn">
+                  <form action="/Admin/EnrollWHInfo" method="POST">
+                    <input id="warehouseID" name="warehouseID" type="hidden" value="<%= items['item' + i].warehouseID %>">
+                    <input id="providerID" name="providerID" type="hidden" value="<%= items['item' + i].providerID %>">
+                    <button class="btn btn-td btn-info">INFO</button>
+                  </form>
+                </td>   
                 <td class="col-1"></td>
                 <td id="td-btn">
                   <button type="button" class="btn btn-td btn-info" onclick="adClick(<%= i %>, 2)">View</button>

--- a/Views/User/Buyer/by_RequestStatus.ejs
+++ b/Views/User/Buyer/by_RequestStatus.ejs
@@ -30,10 +30,12 @@
         <table class="board-table table">
           <thead class="thead-dark">
             <tr>
-              <th>WarehouseID</th>
+              <th>Req ID</th>
+              <th>Warehouse ID</th>
               <th>State</th>
-              <th>Total Fee($)</th>
+              <th>Total Amount ($)</th>
               <th>Rental Period</th>
+              <th>Info</th>
               <th></th>
             </tr>
           </thead>
@@ -41,10 +43,17 @@
             <% for(var i = 0; i < Object.keys(items).length; i++) { %>
             <% if(['ReqByBuyer', 'ReqByAdmin'].includes(items['item' + i].reqType)){ %>
             <tr class="table-warning">
+              <td><%= items['item' + i].reqID %></td>
               <td><%= items['item' + i].warehouseID %></td>
               <td>Pending Approval</td>
               <td><%= items['item' + i].amounts %></td>
               <td><%= items['item' + i].startDate %> ~ <%= items['item' + i].endDate %></td>
+              <td id="td-btn">
+                <form action="/Buyer/RequestWHInfo" method="POST">
+                  <input id="reqID" name="reqID" type="hidden" value="<%= items['item' + i].reqID %>">
+                  <button class="btn btn-td btn-info">INFO</button>
+                </form>
+              </td>
               <td id="td-btn">
                 <button type="button" class="btn btn-td btn-grey" onclick="byClick(<%= i %>, 0)">Cancel</button>
               </td>
@@ -52,6 +61,7 @@
             <% } %>
             <% if(['RejByPv2', 'RejByPv3', 'RejByAdmin'].includes(items['item' + i].reqType)){ %>
             <tr class="table-danger">
+              <td><%= items['item' + i].reqID %></td>
               <td><%= items['item' + i].warehouseID %></td>
               <% if (items['item' + i].reqType.includes('RejByPv')) { %>
               <td>Rejected By Provider</td>
@@ -60,6 +70,12 @@
               <% } %>
               <td><%= items['item' + i].amounts %></td>
               <td><%= items['item' + i].startDate %> ~ <%= items['item' + i].endDate %></td>
+              <td id="td-btn">
+                <form action="/Buyer/RequestWHInfo" method="POST">
+                  <input id="reqID" name="reqID" type="hidden" value="<%= items['item' + i].reqID %>">
+                  <button class="btn btn-td btn-info">INFO</button>
+                </form>
+              </td>
               <td id="td-btn">
                 <button type="button" class="btn btn-td btn-info" onclick="byClick(<%= i %>, 2)">View</button>
               </td>
@@ -74,12 +90,14 @@
         <h2 class="mt-5 mb-3">Payment List</h2>
         <table class="board-table table">
           <thead class="thead-dark">
-            <tr>
+            <tr>              
               <th>Check List</th>
+              <th>Req ID</th>
               <th>Warehouse ID</th>
               <th>State</th>
-              <th>Total Amount</th>
-              <th>Period</th>
+              <th>Total Amount ($)</th>
+              <th>Period</th>              
+              <th>Info</th>
               <th></th>
               <th></th>
             </tr>
@@ -97,10 +115,17 @@
                 <input type="checkbox" name="paymentCheck" value="<%= items['item' + i].amounts %>"
                   onclick='getCheckboxValue(event)' />
               </td>
+              <td><%= items['item' + i].reqID %></td>
               <td><%= items['item' + i].warehouseID %></td>
               <td>Waiting for Payment</td>
               <td id="amounts<%= i %>"><%= items['item' + i].amounts %></td>
               <td><%= items['item' + i].startDate %> ~ <%= items['item' + i].endDate %></td>
+              <td id="td-btn">
+                <form action="/Buyer/RequestWHInfo" method="POST">
+                  <input id="reqID" name="reqID" type="hidden" value="<%= items['item' + i].reqID %>">
+                  <button class="btn btn-td btn-info">INFO</button>
+                </form>
+              </td>
               <td id="td-btn"><button type="button" class="btn btn-td btn-info" onclick="byClick(<%= i %>, 1)">Pay</button></td>
               <td id="td-btn"><button type="button" class="btn btn-td btn-grey" onclick="byClick(<%= i %>, 0)">Cancel</button></td>
             </tr>

--- a/Views/User/Provider/pv_MyWH.ejs
+++ b/Views/User/Provider/pv_MyWH.ejs
@@ -126,10 +126,13 @@
         <table class="board-table table">
           <thead class="thead-dark">
             <tr>
+              <th>Req ID</th>
               <th>Warehouse ID</th>
-              <th>Warehouse Name</th>
+              <th>Buyer ID</th>
               <th>State</th>
-              <th>Action</th>
+              <th>Rental Period</th>
+              <th>Info</th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -138,9 +141,17 @@
 
             <% if (requestItems['item' + i].reqType === 'ReqByAdmin') { %>
             <tr class="table-warning">
+              <td><%= requestItems['item' + i].reqID %></td>
               <td><%= requestItems['item' + i].warehouseID %></td>
-              <td><%= requestItems['item' + i].warehouseName %></td>
+              <td><%= requestItems['item' + i].buyerID %></td>
               <td>Pending Approval</td>
+              <td><%= requestItems['item' + i].startDate %> ~ <%= requestItems['item' + i].endDate %></td>
+              <td id="td-btn">
+                <form action="/Provider/RequestWHInfo" method="POST">
+                  <input id="reqID" name="reqID" type="hidden" value="<%= requestItems['item' + i].reqID %>">
+                  <button class="btn btn-td btn-info">INFO</button>
+                </form>
+              </td>
               <td id="td-btn">
                 <button class="btn btn-td btn-success" onclick="pvClick(1, <%= i %>, 1)" type="button">Approve</button>
                 <button class="btn btn-td btn-danger" onclick="pvClick(1, <%= i %>, 0)" type="button">Reject</button>
@@ -149,9 +160,17 @@
 
             <% } else if (requestItems['item' + i].reqType == 'ReqByPv') { %>
             <tr class="table-basic">
+              <td><%= requestItems['item' + i].reqID %></td>
               <td><%= requestItems['item' + i].warehouseID %></td>
-              <td><%= requestItems['item' + i].warehouseName %></td>
+              <td><%= requestItems['item' + i].buyerID %></td>
               <td>Waiting for Payment</td>
+              <td><%= requestItems['item' + i].startDate %> ~ <%= requestItems['item' + i].endDate %></td>
+              <td id="td-btn">
+                <form action="/Provider/RequestWHInfo" method="POST">
+                  <input id="reqID" name="reqID" type="hidden" value="<%= requestItems['item' + i].reqID %>">
+                  <button class="btn btn-td btn-info">INFO</button>
+                </form>
+              </td>
               <td id="td-btn">
                 <button class="btn btn-td btn-danger" onclick="pvClick(1, <%= i %>, 0)" type="button">Reject</button>
               </td>
@@ -159,9 +178,17 @@
 
             <% } else if (requestItems['item' + i].reqType.includes('CnlByBuyer')) { %>
             <tr class="table-danger">
+              <td><%= requestItems['item' + i].reqID %></td>
               <td><%= requestItems['item' + i].warehouseID %></td>
-              <td><%= requestItems['item' + i].warehouseName %></td>
+              <td><%= requestItems['item' + i].buyerID %></td>
               <td>Canceled By Buyer</td>
+              <td><%= requestItems['item' + i].startDate %> ~ <%= requestItems['item' + i].endDate %></td>
+              <td id="td-btn">
+                <form action="/Provider/RequestWHInfo" method="POST">
+                  <input id="reqID" name="reqID" type="hidden" value="<%= requestItems['item' + i].reqID %>">
+                  <button class="btn btn-td btn-info">INFO</button>
+                </form>
+              </td>
               <td id="td-btn">
                 <button class="btn btn-td btn-info" onclick="pvClick(1, <%= i %>, 2)" type="button">View</button>
               </td>

--- a/Views/User/RequestWHInfo.ejs
+++ b/Views/User/RequestWHInfo.ejs
@@ -77,7 +77,7 @@
           </tbody>
         </table>
       </div>
-      <% if (session.type === 'admin') { %>
+      <% if (session.type === 'admin' || session.type === 'buyer') { %>
       <div class="container">
         <h2 class="mt-5 mb-3">Provider Info</h2>
         <table class="table table-bordered">

--- a/Views/User/RequestWHInfo.ejs
+++ b/Views/User/RequestWHInfo.ejs
@@ -16,6 +16,37 @@
     </header>
     <section>
       <div class="container">
+        <h2 class="mt-5 mb-3">Buy Request Info</h2>
+        <table class="table table-bordered">
+          <tbody>
+            <tr>
+              <th class="thead-dark-vertical">Req ID</th>
+              <td><%= ReqItems.reqID %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Req Date</th>
+              <td><%= ReqItems.reqDate %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Warehouse ID</th>
+              <td><%= ReqItems.warehouseID %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Total Amount</th>
+              <td><%= ReqItems.amounts %> $</td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Rental Area</th>
+              <td><%= ReqItems.area %> m²</td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Rental Period</th>
+              <td><%= ReqItems.startDate %> ~ <%= ReqItems.endDate %></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="container">
         <h2 class="mt-5 mb-3">Warehouse Info</h2>
         <table class="table table-bordered">
           <tbody>
@@ -114,45 +145,46 @@
       </div>
       <% } %>
       <% if (session.type === 'provider' || session.type === 'admin') { %>
-        <div class="container">
-          <h2 class="mt-5 mb-3">Buyer Info</h2>
-          <table class="table table-bordered">
-            <tbody>
-              <tr>
-                <th class="thead-dark-vertical">Buyer ID</th>
-                <td><%= BYitems.memberID %></td>
-              </tr>
-              <tr>
-                <th class="thead-dark-vertical">Buyer Name</th>
-                <td><%= BYitems.name %></td>
-              </tr>
-              <tr>
-                <th class="thead-dark-vertical">National</th>
-                <td><%= BYitems.national %></td>
-              </tr>
-              <tr>
-                <th rowspan="2" class="thead-dark-vertical">Address</th>
-                <td><%= BYitems.zipcode %></td>
-              </tr>
-              <tr>
-                <td><%= BYitems.address %></td>
-              </tr>
-              <tr>
-                <th class="thead-dark-vertical">Email</th>
-                <td><%= BYitems.email %></td>
-              </tr>
-              <tr>
-                <th class="thead-dark-vertical">Contact Number</th>
-                <td><%= BYitems.contactNumber %></td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <% } %>
+      <div class="container">
+        <h2 class="mt-5 mb-3">Buyer Info</h2>
+        <table class="table table-bordered">
+          <tbody>
+            <tr>
+              <th class="thead-dark-vertical">Buyer ID</th>
+              <td><%= BYitems.memberID %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Buyer Name</th>
+              <td><%= BYitems.name %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">National</th>
+              <td><%= BYitems.national %></td>
+            </tr>
+            <tr>
+              <th rowspan="2" class="thead-dark-vertical">Address</th>
+              <td><%= BYitems.zipcode %></td>
+            </tr>
+            <tr>
+              <td><%= BYitems.address %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Email</th>
+              <td><%= BYitems.email %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Contact Number</th>
+              <td><%= BYitems.contactNumber %></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <% } %>
     </section>
     <footer>
       <%- include('../footer') %>
     </footer>
   </div>
 </body>
+
 </html>

--- a/Views/User/RequestWHInfo.ejs
+++ b/Views/User/RequestWHInfo.ejs
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+
+<head>
+  <%- include('../head') %>
+  <script src="https://cdn.rawgit.com/mgalante/jquery.redirect/master/jquery.redirect.js"></script>
+</head>
+
+<body>
+  <div class="wrap">
+    <header>
+      <%- include('../nav_Bar') %>
+      <div class="page-header page-header-small">
+        <div class="page-header-image" data-parallax="true" style="background-image: url('/Image/about_WH.jpg');"></div>
+      </div>
+    </header>
+    <section>
+      <div class="container">
+        <h2 class="mt-5 mb-3">Warehouse Info</h2>
+        <table class="table table-bordered">
+          <tbody>
+            <tr>
+              <th class="thead-dark-vertical">Warehouse ID</th>
+              <td><%= WHitems.warehouseID %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Warehouse Name</th>
+              <td><%= WHitems.warehouseName %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Zipcode</th>
+              <td><%= WHitems.zipcode %></td>
+            </tr>
+            <tr>
+              <th rowspan="2" class="thead-dark-vertical">Address</th>
+              <td><%= WHitems.address %></td>
+            </tr>
+            <tr>
+              <td><%= WHitems.addressDetail %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Contact Email</th>
+              <td><%= WHitems.warehouseEmail %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Contact Tel</th>
+              <td><%= WHitems.warehouseTEL %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Enrolled Date</th>
+              <td><%= WHitems.enrolledDate %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Land Area</th>
+              <td><%= WHitems.landArea %> m²</td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Floor Area</th>
+              <td><%= WHitems.floorArea %> m²</td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Usable Area</th>
+              <td><%= WHitems.useableArea %> m²</td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Price Per Area</th>
+              <td><%= WHitems.perprice %> $</td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Info Comment</th>
+              <td><%= WHitems.infoComment %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">ETC</th>
+              <td><%= WHitems.etcComment %></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <% if (session.type === 'admin') { %>
+      <div class="container">
+        <h2 class="mt-5 mb-3">Provider Info</h2>
+        <table class="table table-bordered">
+          <tbody>
+            <tr>
+              <th class="thead-dark-vertical">Provider ID</th>
+              <td><%= PVitems.memberID %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Provider Name</th>
+              <td><%= PVitems.name %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">National</th>
+              <td><%= PVitems.national %></td>
+            </tr>
+            <tr>
+              <th rowspan="2" class="thead-dark-vertical">Address</th>
+              <td><%= PVitems.zipcode %></td>
+            </tr>
+            <tr>
+              <td><%= PVitems.address %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Email</th>
+              <td><%= PVitems.email %></td>
+            </tr>
+            <tr>
+              <th class="thead-dark-vertical">Contact Number</th>
+              <td><%= PVitems.contactNumber %></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <% } %>
+      <% if (session.type === 'provider' || session.type === 'admin') { %>
+        <div class="container">
+          <h2 class="mt-5 mb-3">Buyer Info</h2>
+          <table class="table table-bordered">
+            <tbody>
+              <tr>
+                <th class="thead-dark-vertical">Buyer ID</th>
+                <td><%= BYitems.memberID %></td>
+              </tr>
+              <tr>
+                <th class="thead-dark-vertical">Buyer Name</th>
+                <td><%= BYitems.name %></td>
+              </tr>
+              <tr>
+                <th class="thead-dark-vertical">National</th>
+                <td><%= BYitems.national %></td>
+              </tr>
+              <tr>
+                <th rowspan="2" class="thead-dark-vertical">Address</th>
+                <td><%= BYitems.zipcode %></td>
+              </tr>
+              <tr>
+                <td><%= BYitems.address %></td>
+              </tr>
+              <tr>
+                <th class="thead-dark-vertical">Email</th>
+                <td><%= BYitems.email %></td>
+              </tr>
+              <tr>
+                <th class="thead-dark-vertical">Contact Number</th>
+                <td><%= BYitems.contactNumber %></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <% } %>
+    </section>
+    <footer>
+      <%- include('../footer') %>
+    </footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## 개요
창고 사용 요청과 수락 또는 거절, 결제 과정에서 창고의 정보, Provider의 정보, Buyer의 정보, Request의 정보를 보여줄 수 있도록 함
## 작업사항
- [x] Request, Warehouse, Provider, Buyer의 정보를 Admin이 창고 사용 요청을 수락/거절 하는 과정에서 확인할 수 있도록 추가
- [x] Request, Warehouse,  Buyer의 정보를 Provider가 창고 사용 요청을 수락/거절 하는 과정에서 확인할 수 있도록 추가
- [x] Request, Warehouse, Provider의 정보를 Buyer가 창고 사용 요청을 수락/거절 하는 과정에서 확인할 수 있도록 추가
- [x] Request, Warehouse, Provider, Buyer의 정보를 추가할 페이지 추가
- [x] 창고 사용 요청을 수락/거절하는 테이블의 내용과 헤더 수정
- [x] 창고 사용 요청을 수락/거절하는 테이블의 UI 수정
## 변경로직
### 변경전
창고 사용 요청과 수락 또는 거절, 결제 과정에서 창고의 정보를 확인할 수 없었음
### 변경후
창고 사용 요청과 수락 또는 거절, 결제 과정에서 창고의 정보를 확인할 수 있음
## 사용방법
Admin / Provider / Buyer 각자의 계정에서 해당 페이지 접속 후 Info 페이지 확인
## 기타


resolved: #220 