### PR TITLE
update: add modal to contact admin

### DIFF
--- a/Views/User/Buyer/by_FindWH.ejs
+++ b/Views/User/Buyer/by_FindWH.ejs
@@ -74,10 +74,20 @@
           </table>
 
           <button class="btn btn-warning btn-block mb-4 collapsed" id="btnInquire" data-toggle="collapse" data-target="#inquire">Inquire</button>
-          <button class="btn btn-block mb-4" id="btnContact" disabled>
+          <button class="btn btn-warning btn-block mb-4" id="btnContact">
             <i class="fas fa-phone-alt" style="margin-right: 5px;"></i>
             Please contact us
           </button>
+          <div class="black_bg"></div>
+          <div class="modal_wrap">
+            <div class="modal_body_2">
+              <h4>Contact service@autoingroup.com</h4>
+              <div class="modal_close">
+                <button type="button" class="btn btn-grey">Close</button>
+                </div>
+              </div>
+            </div>
+          </div>
 
           <div id="inquire" class="collapse">
             <div class="form-group row">
@@ -115,7 +125,7 @@
       </div>
     </section>
     <footer>
-      <%- include('../../footer') %>
+      <%- include('../../footer_forMain') %>
     </footer>
   </div>
 </body>
@@ -124,5 +134,17 @@
 <script async defer src="https://maps.googleapis.com/maps/api/js?key=<%= process.env.GOOGLE_MAP_JAVASCRIPT_KEY %>&callback=initMap"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/tempusdominus-bootstrap-4/5.0.1/js/tempusdominus-bootstrap-4.min.js">
+</script>
+<script>
+  window.onload = function () {
+  function onClick() {
+    document.querySelector('.modal_wrap').style.display = 'block';
+  }
+  function offClick() {
+    document.querySelector('.modal_wrap').style.display = 'none';
+  }
+  document.querySelector('#btnContact').addEventListener('click', onClick);
+  document.querySelector('.modal_close').addEventListener('click', offClick);
+};
 </script>
 </html>


### PR DESCRIPTION
## 개요
버튼 클릭시 모달창 추가

## 작업사항
search warehouse 페이지에서 공공데이터 연결 창고의 contact 버튼 클릭시 admin의 연락처를 안내하는 모달 창 생성

## 변경로직
### 변경전
contact 버튼 비활성화
### 변경후
contact 버튼 클릭시 회색 배경위에 모달창으로 admin의 메일 주소를 안내함


resolved: #229