### PR TITLE
Bug/211 sign up bug

### DIFF
--- a/Public/JS/signUP.js
+++ b/Public/JS/signUP.js
@@ -32,7 +32,7 @@
                     if (data == "errortype7")
                         swalError('ID must be filled first', () => EffectivenessPw = false);
                     if (data === "errortype1")
-                        swalError('Password must be at least 8 characters long and must contain all numbers/case letters/special characters.', () => EffectivenessPw = false);
+                        swalError('Password must be at least 8 characters long and must contain at least one number, upper or lower case and special characters(@$!%*#?&-).', () => EffectivenessPw = false);
                     else if (data === "errortype2")
                         swalError('You can not use same letter 4 times', () => EffectivenessPw = false);
                     else if (data === "errortype3")

--- a/Public/JS/signUP.js
+++ b/Public/JS/signUP.js
@@ -129,6 +129,7 @@
             var id = $("#memberID").val();
             var pw = $("#password").val();
             var name = $("#name").val();
+            var textReg = /^[a-zA-Z0-9\s$@$!%*#?&\-,]*$/;
 
             if (!id)
                 swalError('You have to insert your Id');
@@ -142,10 +143,18 @@
                 swalError('You have to check Password Effectiveness');
             else if (!email)
                 swalError('You have to insert your email');
+            else if (!zipcode)
+                swalError('You have to insert your zipcode');
             else if (!address)
                 swalError('You have to insert your address');
             else if (!national)
                 swalError('You have to insert your country');
+            else if (false === textReg.test(name))
+                swalError('Only english, numbers, blank, special character(@$!%*#?&-,) can be entered in name field');
+            else if (false === textReg.test(address))
+                swalError('Only english, numbers, blank, special character(@$!%*#?&-,) can be entered in address field');
+                else if (false === textReg.test(national))
+                swalError('Only english, numbers, blank, special character(@$!%*#?&-,) can be entered in nation field');
             //finish all test
             else {
                 var formData = $("#regForm").serialize();

--- a/Routes/user_Register.js
+++ b/Routes/user_Register.js
@@ -50,7 +50,7 @@ exports.checkPW = function (req, res, app, db) {
     var id = attr.id;
     var pw = attr.pw;
     var c_p = attr.c_p;
-    var pwReg = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&-])[A-Za-z\d$@$!%*#?&-]{8,}$/;
+    var pwReg = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&-])[A-Za-z\d$@$!%*#?&\-]{8,}$/;
     var koreancheck = /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/;
 
     if (false === pwReg.test(pw)) {

--- a/Routes/user_Register.js
+++ b/Routes/user_Register.js
@@ -50,7 +50,7 @@ exports.checkPW = function (req, res, app, db) {
     var id = attr.id;
     var pw = attr.pw;
     var c_p = attr.c_p;
-    var pwReg = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&-]{8,}$/;
+    var pwReg = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&-])[A-Za-z\d$@$!%*#?&-]{8,}$/;
     var koreancheck = /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/;
 
     if (false === pwReg.test(pw)) {

--- a/Routes/user_Register.js
+++ b/Routes/user_Register.js
@@ -50,10 +50,10 @@ exports.checkPW = function (req, res, app, db) {
     var id = attr.id;
     var pw = attr.pw;
     var c_p = attr.c_p;
-    var reg = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,}$/;
+    var pwReg = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&-]{8,}$/;
     var koreancheck = /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/;
 
-    if (false === reg.test(pw)) {
+    if (false === pwReg.test(pw)) {
         //error all
         res.send("errortype1");
     } else if (id == '') {

--- a/Views/User/user_Register.ejs
+++ b/Views/User/user_Register.ejs
@@ -34,21 +34,19 @@
               <div class="form-group row">
                 <div class="col-sm-12">
                   <input type="text" name="type" id="type" value="<%= req.query.userType %>" style="display: none;">
-                  <input type="text" class="form-control" id="password" name="password" placeholder="Password">
+                  <input type="password" class="form-control" id="password" name="password" placeholder="Password">
                 </div>
               </div>
               <div class="form-group row">
                 <div class="col-sm-9">
-                  <input type="text" class="form-control" id="passwordConfirmation" name="passwordConfirmation"
-                    placeholder="Password Confirm" />
+                  <input type="password" class="form-control" id="passwordConfirmation" name="passwordConfirmation" placeholder="Password Confirm" />
                   <% if(locals.err){ %>
                   <span class="invalid-feedback"><%= locals.err %></span>
                   <% } %>
                 </div>
                 <div class="col-sm-3">
                   <label id="form-control-btn" class="form-control" for="passwordCheckButton">PW Check</label>
-                  <input type="button" class="upload-btn-hidden" id="passwordCheckButton" name="passwordCheckButton"
-                    value="PW Check"><br>
+                  <input type="button" class="upload-btn-hidden" id="passwordCheckButton" name="passwordCheckButton" value="PW Check"><br>
                 </div>
               </div>
               <div class="form-group row">


### PR DESCRIPTION
## 개요
회원가입 창에서 발생하는 오류 수정과 사용성 개선
## 작업사항
- [x] 비밀번호 입력시 보이지 않게 처리
- [x] 주소 영어 소/대문자 특수문자 공백만 가능하도록 정규식 추가 후 에러 메시지 추가
- [x] 이름 영어 소/대문자 특수문자 공백만 가능하도록 정규식 추가 후 에러 메시지 추가
- [x] 국가 영어 소/대문자 특수문자 공백만 가능하도록 정규식 추가 후 에러 메시지 추가
- [x] 우편번호 빈칸 여부 확인을 하지 않는 오류 수정
- [x] 비밀번호 규정 약화하기 (대문자 규정 삭제)
## 변경로직
### 변경전
- 8글자 이상, 소문자, 대문자, 특수문자, 숫자가 모두 들어가는 비밀번호 사용 가능
- 주소, 이름, 국가에서 형식을 확인하지 않아 회원가입이 정상적으로 이루어지지 않는 경우 발생
- 우편번호의 빈칸 여부를 확인하지 않음
- 비밀번호 입력시 그대로 보임
### 변경후
- 8글자 이상, 소문자 또는 대문자, 특수문자, 숫자가 모두 들어가는 비밀번호 사용 가능
- 주소, 이름, 국가에서 형식을 확인
- 우편번호의 빈칸 여부를 확인
- 비밀번호 입력시 보이지 않음
## 사용방법
회원가입 페이지 접속
## 기타


resolved: #211