### PR TITLE
Feature/243 IoT 페이지의 Item Edit과 Register에 관련된 버그 수정과 사용성 개선

### DIFF
--- a/Routes/iot.js
+++ b/Routes/iot.js
@@ -65,7 +65,7 @@ module.exports = function (app, db) {
     });
 
     router.post('/EditItem', (req, res, next) => {
-        res.render('IoT/iot_EditItem', { 'rfid': req.body.itemEdit, 'session': req.session })
+        res.render('IoT/iot_EditItem', { 'RFID': req.body.RFID, 'name': req.body.name, 'num': req.body.num, 'session': req.session })
     });
 
     router.post('/EditSave', (req, res, next) => {

--- a/Routes/iot_EditItem.js
+++ b/Routes/iot_EditItem.js
@@ -1,14 +1,14 @@
 exports.editItem = function (req, res, db) {
-    var rfid = req.body.editItem_rfid;
-    var name = req.body.editItem_name;
-    var num = req.body.editItem_num;
+    var rfid = req.body.RFID;
+    var name = req.body.name;
+    var num = req.body.num;
 
     var editSQL = `UPDATE iot SET name='${name}',num='${num}' WHERE rfid='${rfid}'`
     var check = db.query(editSQL);
     if (!check) {
-        console.log("error ocurred", error);
-        res.redirect('Warehousing');
+        console.log("error ocurred", error);        
+        res.send("error")
     } else {
-        res.redirect('Warehousing');
+        res.send("success")
     }
 }

--- a/Routes/iot_EditItem.js
+++ b/Routes/iot_EditItem.js
@@ -1,14 +1,21 @@
 exports.editItem = function (req, res, db) {
-    var rfid = req.body.RFID;
+    var RFID = req.body.RFID;
     var name = req.body.name;
     var num = req.body.num;
 
-    var editSQL = `UPDATE iot SET name='${name}',num='${num}' WHERE rfid='${rfid}'`
-    var check = db.query(editSQL);
-    if (!check) {
-        console.log("error ocurred");        
-        res.send("error")
+    var check = db.query(`Select rfid from iot where rfid='` + RFID + `'`);
+    console.log(check);
+    if (check.length == 0) {
+        console.log("err: editItem no RFID");
+        res.send("error1")
     } else {
-        res.send("success")
+        var editSQL = `UPDATE iot SET name='${name}',num='${num}' WHERE rfid='${RFID}'`
+        var row = db.query(editSQL);
+        if (!row) {
+            console.log("err: editItem");
+            res.send("error")
+        } else {
+            res.send("success")
+        }
     }
 }

--- a/Routes/iot_EditItem.js
+++ b/Routes/iot_EditItem.js
@@ -6,7 +6,7 @@ exports.editItem = function (req, res, db) {
     var editSQL = `UPDATE iot SET name='${name}',num='${num}' WHERE rfid='${rfid}'`
     var check = db.query(editSQL);
     if (!check) {
-        console.log("error ocurred", error);        
+        console.log("error ocurred");        
         res.send("error")
     } else {
         res.send("success")

--- a/Routes/iot_RegisterItem.js
+++ b/Routes/iot_RegisterItem.js
@@ -1,13 +1,13 @@
 exports.registerItem = function (req, res, db) {
-    var rfid = req.body.rfid.toUpperCase();
+    var RFID = req.body.RFID.toUpperCase();
     var name = req.body.name;
     var num = req.body.num;
     var received = 0;
-    var picture = `./${rfid}.jpg`;
+    var picture = `./${RFID}.jpg`;
     var id = req.session['memberID'];
     var wid = req.session['warehouseID'];
 
-    var row = db.query(`INSERT INTO iot VALUES('${rfid}', '${id}', '${name}', ${num}, ${received}, '${picture}',${wid});`);
+    var row = db.query(`INSERT INTO iot VALUES('${RFID}', '${id}', '${name}', ${num}, ${received}, '${picture}',${wid});`);
     if (!row) console.log('err: registerItem');
     else res.redirect('Warehousing');
 }

--- a/Routes/iot_RegisterItem.js
+++ b/Routes/iot_RegisterItem.js
@@ -7,7 +7,18 @@ exports.registerItem = function (req, res, db) {
     var id = req.session['memberID'];
     var wid = req.session['warehouseID'];
 
-    var row = db.query(`INSERT INTO iot VALUES('${RFID}', '${id}', '${name}', ${num}, ${received}, '${picture}',${wid});`);
-    if (!row) console.log('err: registerItem');
-    else res.redirect('Warehousing');
+    var check = db.query(`Select rfid from iot where rfid='` + RFID + `'`);
+    console.log(check);
+    if (check.length > 0) {
+        console.log("err: registerItem duplicate RFID");
+        res.send("error1")
+    } else {
+        var row = db.query(`INSERT INTO iot VALUES('${RFID}', '${id}', '${name}', ${num}, ${received}, '${picture}',${wid});`);
+        if (!row) {
+            console.log("err: registerItem");
+            res.send("error")
+        } else {
+            res.send("success")
+        }
+    }
 }

--- a/Views/IoT/iot_EditItem.ejs
+++ b/Views/IoT/iot_EditItem.ejs
@@ -13,33 +13,34 @@
     </header>
     <section id="iot">
       <div class="container-info mb-3">
-          <h2 class="mb-3">Change Product Information</h2>
-        <form action="/IoT/EditSave" method="POST">
-            <table class="board-table table">
-              <thead class="thead-dark">
-                <tr>
-                  <th>Info List</th>
-                  <th>Product Info</th>
-                </tr>
-              </thead>
-              <tbody class="table-bg">
-                <tr>
-                  <th>RFID</th>
-                  <td><input type="text" name="editItem_rfid" id="editItem_rfid" class="box" value="<%= RFID %>" readonly></td>
-                </tr>
-                <tr>
-                  <th>Product Name</th>
-                  <td><input type="text" name="editItem_name" id="editItem_name" class="box" value="<%= name %>"></td>
-                </tr>
-                <tr>
-                  <th>Product Quantity</th>
-                  <td><input type="number" name="editItem_num" id="editItem_num" class="box" value="<%= num %>"></td>
-                </tr>
-              </tbody>
-            </table>
-            <div class="center-wrap">
-              <button type="submit" class="btn btn-main btn-two-l">Save</button>
-            </div>
+        <h2 class="mb-3">Edit Product Information</h2>
+        <form action="/IoT/EditSave" method="POST" id="itemForm">
+          <table class="board-table table">
+            <thead class="thead-dark">
+              <tr>
+                <th>Info List</th>
+                <th>Product Info</th>
+              </tr>
+            </thead>
+            <tbody class="table-bg">
+              <tr>
+                <th>RFID</th>
+                <td><input type="text" name="RFID" id="RFID" class="box" value="<%= RFID %>" readonly>
+                </td>
+              </tr>
+              <tr>
+                <th>Product Name</th>
+                <td><input type="text" name="name" id="name" class="box" value="<%= name %>"></td>
+              </tr>
+              <tr>
+                <th>Product Quantity</th>
+                <td><input type="number" name="num" id="num" class="box" value="<%= num %>"></td>
+              </tr>
+            </tbody>
+          </table>
+          <div class="center-wrap">
+            <button type="submit" class="btn btn-main btn-two-l">Save</button>
+          </div>
         </form>
         <button class="btn btn-grey btn-two-l ml-1" onclick="location.href='Warehousing'">Back</button>
       </div>
@@ -50,5 +51,72 @@
   </footer>
   </div>
 </body>
+
+<script>
+  $(document).ready(function () {
+    $("#itemForm").submit(function (evt) {
+      evt.preventDefault();
+
+      var textReg = /^[a-zA-Z0-9\s$@$!%*#?&\-,]*$/;
+      var numReg = /^[0-9]*$/;
+      var RFID = $("#RFID").val();
+      var name = $("#name").val();
+      var num = $("#num").val();
+
+      var swalError = (text) => Swal.fire({
+        icon: 'error',
+        title: 'Fail',
+        text: text
+      });
+
+      if (!RFID)
+        swalError('Do not delete RFID');
+      else if (!name)
+        swalError(`You have to insert item's name`);
+      else if (!num)
+        swalError(`You have to insert your warehouse contact telephone number`);
+      else if (false === textReg.test(name))
+        swalError('Only english, numbers, blank, special character(@$!%*#?&-,) can be entered in name field');
+      else if (false === numReg.test(num))
+        swalError('Only numbers can be entered in quantity field');
+
+      //finish all test
+      else {
+        var formData = new FormData(document.getElementById('itemForm'));
+        $.ajax({
+          url: $(this).attr('action'),
+          type: 'POST',
+          data: formData,
+          processData: false,
+          contentType: false,
+          success: function (data) {
+            if (data == "success") {
+              Swal.fire({
+                icon: 'success',
+                title: 'Success',
+                text: 'Successfully completed product edit.',
+              }).then(() => {
+                location.href = "Warehousing";
+              })
+            } else {
+              Swal.fire({
+                icon: 'error',
+                title: 'Fail',
+                text: 'An error was occurred.',
+              })
+            }
+          },
+          error: function (request, status, error) {
+            Swal.fire({
+              title: 'Error',
+              html: `code: ${request.status}<br>message: ${request.responseText}<br>error: ${error}`,
+              icon: 'error'
+            });
+          }
+        })
+      }
+    })
+  })
+</script>
 
 </html>

--- a/Views/IoT/iot_EditItem.ejs
+++ b/Views/IoT/iot_EditItem.ejs
@@ -25,15 +25,15 @@
               <tbody class="table-bg">
                 <tr>
                   <th>RFID</th>
-                  <td><input type="text" name="editItem_rfid" id="editItem_rfid" class="box" value="<%= rfid %>" readonly></td>
+                  <td><input type="text" name="editItem_rfid" id="editItem_rfid" class="box" value="<%= RFID %>" readonly></td>
                 </tr>
                 <tr>
                   <th>Product Name</th>
-                  <td><input type="text" name="editItem_name" id="editItem_name" class="box"></td>
+                  <td><input type="text" name="editItem_name" id="editItem_name" class="box" value="<%= name %>"></td>
                 </tr>
                 <tr>
                   <th>Product Quantity</th>
-                  <td><input type="number" name="editItem_num" id="editItem_num" class="box"></td>
+                  <td><input type="number" name="editItem_num" id="editItem_num" class="box" value="<%= num %>"></td>
                 </tr>
               </tbody>
             </table>

--- a/Views/IoT/iot_EditItem.ejs
+++ b/Views/IoT/iot_EditItem.ejs
@@ -90,7 +90,16 @@
           processData: false,
           contentType: false,
           success: function (data) {
-            if (data == "success") {
+            if (data == "error1") {
+              Swal.fire({
+                icon: 'error',
+                title: 'Fail',
+                text: `DO NOT CHANGE RFID!!!`,
+              }).then(() => {
+                location.href = "Warehousing";
+              })
+            }
+            else if (data == "success") {
               Swal.fire({
                 icon: 'success',
                 title: 'Success',

--- a/Views/IoT/iot_RegisterItem.ejs
+++ b/Views/IoT/iot_RegisterItem.ejs
@@ -52,4 +52,83 @@
   </div>
 </body>
 
+<script>
+  $(document).ready(function () {
+    $("#itemForm").submit(function (evt) {
+      evt.preventDefault();
+
+      var textReg = /^[a-zA-Z0-9\s$@$!%*#?&\-,]*$/;
+      var numReg = /^[0-9]*$/;
+      var RFIDReg = /^[0-9A-Fa-f]*$/;
+      var RFID = $("#RFID").val();
+      var name = $("#name").val();
+      var num = $("#num").val();
+
+      var swalError = (text) => Swal.fire({
+        icon: 'error',
+        title: 'Fail',
+        text: text
+      });
+
+      if (!RFID)
+        swalError(`You have to insert item's RFID`);
+      else if (!name)
+        swalError(`You have to insert item's name`);
+      else if (!num)
+        swalError(`You have to insert item's quantity`);
+      else if (false === RFIDReg.test(RFID))
+        swalError('Only hexadecimal can be entered in RFID field');
+      else if (false === textReg.test(name))
+        swalError('Only english, numbers, blank, special character(@$!%*#?&-,) can be entered in name field');
+      else if (false === numReg.test(num))
+        swalError('Only numbers can be entered in quantity field');
+
+      //finish all test
+      else {
+        var formData = new FormData(document.getElementById('itemForm'));
+        $.ajax({
+          url: $(this).attr('action'),
+          type: 'POST',
+          data: formData,
+          processData: false,
+          contentType: false,
+          success: function (data) {
+            if (data == "error1") {
+              Swal.fire({
+                icon: 'error',
+                title: 'Fail',
+                text: `There's the RFID number already inserted. Please try another RFID or delete duplicate RFID and try again.`,
+              }).then(() => {
+                location.href = "Warehousing";
+              })
+            }
+            else if (data == "success") {
+              Swal.fire({
+                icon: 'success',
+                title: 'Success',
+                text: 'Successfully completed product edit.',
+              }).then(() => {
+                location.href = "Warehousing";
+              })
+            } else {
+              Swal.fire({
+                icon: 'error',
+                title: 'Fail',
+                text: 'An error was occurred.',
+              })
+            }
+          },
+          error: function (request, status, error) {
+            Swal.fire({
+              title: 'Error',
+              html: `code: ${request.status}<br>message: ${request.responseText}<br>error: ${error}`,
+              icon: 'error'
+            });
+          }
+        })
+      }
+    })
+  })
+</script>
+
 </html>

--- a/Views/IoT/iot_RegisterItem.ejs
+++ b/Views/IoT/iot_RegisterItem.ejs
@@ -15,7 +15,7 @@
     <section id="iot">
       <div class="container-info">
         <h2 class="mb-3">Register Product</h2>
-        <form action="RegisterItem" method="POST">
+        <form action="RegisterItem" method="POST" id="itemForm">
           <table class="board-table table">
             <thead class="thead-dark">
               <tr>
@@ -26,15 +26,15 @@
             <tbody class="table-bg">
               <tr>
                 <th>RFID</th>
-                <td><input type="text" name="rfid" class="box"></td>
+                <td><input type="text" name="RFID" id="RFID" class="box"></td>
               </tr>
               <tr>
                 <th>Product Name</th>
-                <td><input type="text" name="name" class="box"></td>
+                <td><input type="text" name="name" id="name" class="box"></td>
               </tr>
               <tr>
                 <th>Product Quantity</th>
-                <td><input type="number" name="num" class="box"></td>
+                <td><input type="number" name="num" id="num" class="box"></td>
               </tr>
             </tbody>
           </table>

--- a/Views/IoT/iot_Warehousing.ejs
+++ b/Views/IoT/iot_Warehousing.ejs
@@ -64,7 +64,9 @@
                 <td id="td-btn">
                   <form action="/IoT/EditItem" method="POST">
                     <button class="btn btn-td btn-info">Edit</button>
-                    <input type="hidden" id="itemEdit" name="itemEdit" value="<%= itemlist['item' + i].rfid %>">
+                    <input type="hidden" id="RFID" name="RFID" value="<%= itemlist['item' + i].rfid %>">
+                    <input type="hidden" id="name" name="name" value="<%= itemlist['item' + i].name %>">
+                    <input type="hidden" id="num" name="num" value="<%= itemlist['item' + i].num %>">
                   </form>
                 </td>
                 <td id="td-btn">


### PR DESCRIPTION
## 개요
IoT 페이지의 Item Edit과 Register에 관련된 버그 수정과 사용성 개선
## 작업사항
- [x] 물품 수정시 저장되어 있는 수량과 이름이 보이도록 사용성 개선
- [x] 물품 수정시 수량과 이름이 빈칸이면 에러가 나도록 유효성 검사 추가
- [x] 물품 수정시 수량과 이름에 대한 형식 유효성 검사 추가
- [x] 물품 수정시 RFID가 변경되었을 때 (없는 RFID로 강제 변경) 에러가 뜨도록 수정
- [x] 물품 수정에 성공하면 확인창 출력
- [x] 물품 등록시 RFID, 수량과 이름이 빈칸이면 에러가 나도록 유효성 검사 추가
- [x] 물품 등록시 RFID, 수량과 이름에 대한 형식 유효성 검사 추가
- [x] 물품 등록시 RFID가 중복되었을 때 에러가 뜨도록 수정
- [x] 물품 등록시 성공하면 확인창 출력
- [x] 각각에 맞는 정규식 추가
- [x] 리팩토링
## 변경로직
### 변경전
작업사항에 포함된 내용이 전체적으로 구현되지 않았음
### 변경후
작업사항 참조
## 사용방법
로그인 후 IoT 페이지 접속
## 기타


resolved: #243 #256