### PR TITLE
fix: signup page js

### DIFF
--- a/Public/JS/signUP.js
+++ b/Public/JS/signUP.js
@@ -129,6 +129,10 @@
             var id = $("#memberID").val();
             var pw = $("#password").val();
             var name = $("#name").val();
+            var email = $("#email").val();
+            var zipcode = $("#zipcode").val();
+            var address = $("#address").val();
+            var national = $("#national").val();
             var textReg = /^[a-zA-Z0-9\s$@$!%*#?&\-,]*$/;
 
             if (!id)
@@ -153,7 +157,7 @@
                 swalError('Only english, numbers, blank, special character(@$!%*#?&-,) can be entered in name field');
             else if (false === textReg.test(address))
                 swalError('Only english, numbers, blank, special character(@$!%*#?&-,) can be entered in address field');
-                else if (false === textReg.test(national))
+            else if (false === textReg.test(national))
                 swalError('Only english, numbers, blank, special character(@$!%*#?&-,) can be entered in nation field');
             //finish all test
             else {


### PR DESCRIPTION
## 개요
회원가입 페이지에서 id, pw, name을 제외한 나머지 태그들의 정규식, 빈칸 체크 등이 올바르게 작동하지 않는 문제 해결

## 작업사항
id, pw, name을 제외한 나머지 태그가 올바르게 인식되도록 변경


resolved: #263 